### PR TITLE
Change the groupId and artifactId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <version>5</version>
     </parent>
 
-    <groupId>javax.transaction</groupId>
-    <artifactId>javax.transaction-api</artifactId>
+    <groupId>jakarta.transaction</groupId>
+    <artifactId>jakarta.transaction-api</artifactId>
     <version>1.4-SNAPSHOT</version>
     
     <properties>
@@ -117,8 +117,9 @@
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>spec-version-maven-plugin</artifactId>
-                <version>1.2</version>
+                <version>1.5</version>
                 <configuration>
+                    <specMode>jakarta</specMode>
                     <spec>
                         <nonFinal>${non.final}</nonFinal>
                         <jarType>api</jarType>

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
 
     <groupId>jakarta.transaction</groupId>
     <artifactId>jakarta.transaction-api</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.3.1-SNAPSHOT</version>
     
     <properties>
         <non.final>false</non.final>
         <extension.name>javax.transaction</extension.name>
-        <spec.version>1.4</spec.version>
+        <spec.version>1.3</spec.version>
         <findbugs.version>2.3.1</findbugs.version>
         <findbugs.exclude>exclude.xml</findbugs.exclude>
         <findbugs.threshold>Low</findbugs.threshold>


### PR DESCRIPTION
This is a backport of the already merged https://github.com/eclipse-ee4j/jta-api/pull/7

It also has another commit in to reset the version number to 1.3.1-SNAPSHOT so I can try to do a mvn deploy of the snapshot release.

Signed-off-by: Tom Jenkinson <tom.jenkinson@redhat.com>