### PR TITLE
Jakarta release has wrong OSGi Bundle-SymbolicName

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.transaction</groupId>
     <artifactId>jakarta.transaction-api</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.2-SNAPSHOT</version>
     
     <properties>
         <non.final>false</non.final>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     
     <properties>
         <non.final>false</non.final>
-        <extension.name>javax.transaction</extension.name>
+        <extension.name>jakarta.transaction</extension.name>
         <spec.version>1.3</spec.version>
         <findbugs.version>2.3.1</findbugs.version>
         <findbugs.exclude>exclude.xml</findbugs.exclude>
@@ -132,7 +132,7 @@
                     <execution>
                         <goals>
                             <goal>set-spec-properties</goal>
-                            <goal>check-module</goal>
+                            <!-- <goal>check-module</goal> this fails because the package is not jakarta. -->
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Resolves https://github.com/eclipse-ee4j/jta-api/issues/27

The PR changes the manifest in the following ways from my view of it:
Bundle-SymbolicName: jakarta.transaction-api
Bundle-Name: jakarta.transaction API
Extension-Name: jakarta.transaction

It also disables check-module on the spec plugin as that does not seem happy with an extension-name that does not match the package