### PR TITLE
1.3.2 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.transaction</groupId>
     <artifactId>jakarta.transaction-api</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3-SNAPSHOT</version>
     
     <properties>
         <non.final>false</non.final>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.transaction</groupId>
     <artifactId>jakarta.transaction-api</artifactId>
-    <version>1.3.2-SNAPSHOT</version>
+    <version>1.3.2</version>
     
     <properties>
         <non.final>false</non.final>


### PR DESCRIPTION
Keeping EE4J_8 in sync, after merging https://github.com/eclipse-ee4j/jta-api/tree/1.3.2-RELEASE could be deleted