### PR TITLE
Snapshot version set to 1.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.transaction</groupId>
     <artifactId>jakarta.transaction-api</artifactId>
-    <version>1.3.2-SNAPSHOT</version>
+    <version>1.3.1-SNAPSHOT</version>
     
     <properties>
         <non.final>false</non.final>


### PR DESCRIPTION
Looks like there is some inconsistency in the snapshot version of JTA API in EE4J_8 branch.
Last release in Maven Central is https://search.maven.org/artifact/javax.transaction/javax.transaction-api/1.3/jar
so think that we can keep 1.3.1-SNAPSHOT to be able to run https://jenkins.eclipse.org/jta/job/eclipse-ee4j_jta-api-EE4J_8-release/ job without overriding versions.
