### PR TITLE
Do not make spec a child of the root pom.xml as it can be separately versioned

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
 
     <modules>
         <module>api</module>
-        <module>spec</module>
     </modules>
 
     <licenses>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -25,6 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>transactions-spec</artifactId>
+    <version>1.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta Transactions Specification</name>
 


### PR DESCRIPTION
As per https://www.eclipse.org/lists/ee4j-pmc/msg02098.html

Signed-off-by: Tom Jenkinson <tom.jenkinson@redhat.com>