### PR TITLE
The spec project does not need to use the jakarta.transaction-parent pom.xml

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -17,17 +17,19 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    
     <parent>
-        <groupId>jakarta.transaction</groupId>
-        <artifactId>jakarta.transaction-parent</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>1.0.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <groupId>jakarta.transaction</groupId>
     <artifactId>transactions-spec</artifactId>
     <version>1.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta Transactions Specification</name>
+    <url>https://projects.eclipse.org/projects/ee4j.jta</url>
 
     <properties>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>


### PR DESCRIPTION
I can work around this in the jenkins jobs but it would be useful for future versions to get this in

Signed-off-by: Tom Jenkinson <tom.jenkinson@redhat.com>