### PR TITLE
Move master to 1.3.4-SNAPSHOT after reverting commits moving to 1.4/1.4-SNAPSHOT/1.4.0-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.transaction</groupId>
     <artifactId>jakarta.transaction-api</artifactId>
-    <version>1.3.2-SNAPSHOT</version>
+    <version>1.3.4-SNAPSHOT</version>
     
     <properties>
         <non.final>false</non.final>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <non.final>false</non.final>
         <extension.name>javax.transaction</extension.name>
-        <spec.version>1.4</spec.version>
+        <spec.version>1.3</spec.version>
         <findbugs.version>2.3.1</findbugs.version>
         <findbugs.exclude>exclude.xml</findbugs.exclude>
         <findbugs.threshold>Low</findbugs.threshold>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.transaction</groupId>
     <artifactId>jakarta.transaction-api</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.3.2-SNAPSHOT</version>
     
     <properties>
         <non.final>false</non.final>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>jakarta.transaction</groupId>
     <artifactId>jakarta.transaction-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.3.3-SNAPSHOT</version>
     <name>Jakarta transactions Parent</name>
     <url>https://projects.eclipse.org/projects/ee4j.jta</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>jakarta.transaction</groupId>
     <artifactId>jakarta.transaction-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.3.3-SNAPSHOT</version>
+    <version>1.3.4-SNAPSHOT</version>
     <name>Jakarta transactions Parent</name>
     <url>https://projects.eclipse.org/projects/ee4j.jta</url>
 

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>jakarta.transaction</groupId>
         <artifactId>jakarta.transaction-parent</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.3.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,12 +20,12 @@
     <parent>
         <groupId>jakarta.transaction</groupId>
         <artifactId>jakarta.transaction-parent</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>1.3.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>transactions-spec</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta Transactions Specification</name>
 

--- a/spec/src/main/asciidoc/transactions-spec.adoc
+++ b/spec/src/main/asciidoc/transactions-spec.adoc
@@ -2,7 +2,7 @@
 // Copyright (c) 2017, 2019 Contributors to the Eclipse Foundation
 //
 
-= Jakarta Transactions 1.4
+= Jakarta Transactions 1.3
 :authors: Jakarta Transactions Team, https://projects.eclipse.org/projects/ee4j.jta
 :email: https://dev.eclipse.org/mailman/listinfo/jta-dev
 :version-label!:


### PR DESCRIPTION
As per https://github.com/eclipse-ee4j/jta-api/pull/70#issuecomment-564629932 I am reverting the a couple of version changes and moving to 2.0 (+variants)