### PR TITLE
GitHub Issue #76: javadoc generate fails with OpenJDK 11+, new warnings

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -109,8 +109,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.5.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <compilerArgument>-Xlint:unchecked</compilerArgument>
                 </configuration>
             </plugin>
@@ -255,6 +255,7 @@
     <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.
         ]]>
                     </bottom>
+                    <source>8</source>
                 </configuration>                
                 <executions>
                     <execution>


### PR DESCRIPTION
- add <source>8</source> to javadoc-plugin
- set source/target to java8 in compiler-plugin

Signed-off-by: Markus Stauffer <Markus.Stauffer@gmail.com>