### PR TITLE
GitHub Issue #76: javadoc generate fails with OpenJDK 11+, new warnings

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -255,6 +255,7 @@
     <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.
         ]]>
                     </bottom>
+                    <source>1.7</source>
                 </configuration>                
                 <executions>
                     <execution>


### PR DESCRIPTION
- add <source>1.7</source> to javadoc-plugin

Signed-off-by: Markus Stauffer <Markus.Stauffer@gmail.com>