### PR TITLE
set compiler source and target to 1.8

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -33,6 +33,8 @@
         <non.final>false</non.final>
         <extension.name>javax.transaction</extension.name>
         <spec.version>2.0</spec.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     <name>${extension.name} API</name>
     <description>Jakarta Transactions</description>
@@ -106,8 +108,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.5.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
                     <compilerArgument>-Xlint:unchecked</compilerArgument>
                 </configuration>
             </plugin>
@@ -252,8 +252,8 @@
     <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.
         ]]>
                     </bottom>
-                    <source>1.7</source>
-                </configuration>                
+                    <source>1.8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
JakartaEE9ReleasePlan:
"For inclusion in Jakarta EE 9, specification’s APIs MUST be compiled at the Java SE 8 source level."

Signed-off-by: Markus Stauffer <Markus.Stauffer@gmail.com>