### PR TITLE
Remove version protection range for Interceptor

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -154,7 +154,6 @@
                         <Specification-Vendor>Oracle Corporation</Specification-Vendor>
                         <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
                         <Implementation-Vendor-Id>org.glassfish</Implementation-Vendor-Id>
-                        <Import-Package>jakarta.interceptor.*;version="[1.2,2.0.0)",*</Import-Package>
                         <_include>-${basedir}/osgi.bundle</_include>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
JTA is now protected against versions of Jakarta Interceptor smaller than 2. The Jakarta-ized version of Interceptor has a version of 2.0.0 which therefor triggers this protection at runtime.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>