### PR TITLE
Update Spec chapter headings

### DIFF
--- a/spec/src/main/asciidoc/Transactions.adoc
+++ b/spec/src/main/asciidoc/Transactions.adoc
@@ -6,9 +6,7 @@ Copyright (c) 2020 Eclipse Foundation.
 Oracle and Java are registered trademarks of Oracle and/or its 
 affiliates. Other names may be trademarks of their respective owners. 
 
-== CHAPTER 1 - 
-
-Introduction
+== Introduction
 
 This document describes Jakarta
 Transactions. Jakarta Transactions specifies local Java interfaces between a
@@ -103,9 +101,7 @@ RDBMS
 * Advanced transactional applications written
 in the Java _TM_ programming language
 
-== CHAPTER 2 - 
-
-Relationship to Other Java APIs
+== Relationship to Other Java APIs
 
 This chapter explores the relationship
 between Jakarta Transactions and other Java APIs, including
@@ -163,9 +159,7 @@ protocol for transaction propagation between servers. JTS is intended
 for vendors that provide the transaction system infrastructure for
 enterprise middleware.
 
-== CHAPTER 3 - 
-
-Jakarta Transactions API
+== Jakarta Transactions API
 
 The Jakarta Transactions API consists of
 three elements: a high-level application transaction demarcation
@@ -1352,9 +1346,7 @@ contextNotActiveException) \{
 
 === 
 
-== CHAPTER 4 - 
-
-Jakarta Transactions Support in the Application Server
+== Jakarta Transactions Support in the Application Server
 
 This chapter provides a discussion on
 implementation and usage considerations for application servers to

--- a/spec/src/main/asciidoc/Transactions.adoc
+++ b/spec/src/main/asciidoc/Transactions.adoc
@@ -1540,7 +1540,7 @@ _https://jakarta.ee/specifications/interceptors/2.0/_
 
 === 
 
-===  aPPENDIX
+===  APPENDIX
 
 === Revision History
 

--- a/spec/src/main/asciidoc/Transactions.adoc
+++ b/spec/src/main/asciidoc/Transactions.adoc
@@ -108,7 +108,7 @@ between Jakarta Transactions and other Java APIs, including
 Jakarta Enterprise Beans 4.0, JDBC API, Jakarta Messaging 3.0
 Service, and Java Transaction Service.
 
-== Java SE
+=== Java SE
 
 Java SE provides the API that defines the contract between the transaction manager
 and the resource manager, which allows the transaction manager to enlist and delist

--- a/spec/src/main/asciidoc/Transactions.adoc
+++ b/spec/src/main/asciidoc/Transactions.adoc
@@ -1507,9 +1507,8 @@ The behaviors described in the Javadoc
 specification of the Jakarta Transactions interfaces are required functionality and must
 be implemented by compliant providers.
 
-=== APPENDIX 
-
-=== Related Documents
+[appendix]
+== Related Documents
 
 This specification refers to the following
 documents.
@@ -1534,11 +1533,8 @@ Specification_ , available at _https://jakarta.ee/specifications/cdi/3.0/_
 .  _Jakarta Interceptors 2.0 Specification_ , available at
 _https://jakarta.ee/specifications/interceptors/2.0/_
 
-=== 
-
-===  APPENDIX
-
-=== Revision History
+[appendix]
+== Revision History
 
 == Changes for Version 1.3
 

--- a/spec/src/main/asciidoc/Transactions.adoc
+++ b/spec/src/main/asciidoc/Transactions.adoc
@@ -708,7 +708,7 @@ transaction.
 
 === Transaction Association
 
-=== 
+|===
 
 XAResource
 
@@ -780,7 +780,7 @@ T _0_
 
 T _0_
 
-
+|===
 
 === Externally Controlled connections
 

--- a/spec/src/main/asciidoc/Transactions.adoc
+++ b/spec/src/main/asciidoc/Transactions.adoc
@@ -366,7 +366,7 @@ link:jta.html#a103[See Resource Enlistment].” and
 link:jta.html#a167[See Transaction Association],” for more
 details on resource enlistment and transaction association.
 
-=== [[a96]]Transaction Interface
+=== Transaction Interface
 
 The _Transaction_ interface allows operations
 to be performed on the transaction associated with the target object.
@@ -384,7 +384,7 @@ callbacks.
 These functions are described in the sections
 below.
 
-=== [[a103]]Resource Enlistment
+=== Resource Enlistment
 
 An application server provides the
 application run-time infrastructure that includes transactional resource
@@ -543,7 +543,7 @@ _Transaction_ __ objects are equal, they have the same hash code.
 However, the converse is not necessarily true. Two _Transaction_ __
 objects with the same hash code are not necessarily equal.
 
-=== [[a139]]XAResource Interface
+=== XAResource Interface
 
 The _javax.transaction.xa.XAResource_
 interface is a Java mapping of the industry standard XA interface based
@@ -687,7 +687,7 @@ Thus the _XAResource_ interface specified in
 this document requires that the resource managers be able to support the
 two-phase commit protocol from any thread context.
 
-=== [[a167]]Transaction Association
+=== Transaction Association
 
 Global transactions are associated with a
 transactional resource via the _XAResource.start_ __ method, and
@@ -938,7 +938,7 @@ manager to return any transactions that are currently in a prepared or
 heuristically completed state. It is the responsibility of the
 transaction manager to ignore transactions that do not belong to it.
 
-=== [[a245]]Identifying Resource Manager Instance
+=== Identifying Resource Manager Instance
 
 The _isSameRM_ __ method is invoked by the
 transaction manager to determine if the target _XAResource_ __ object

--- a/spec/src/main/asciidoc/Transactions.adoc
+++ b/spec/src/main/asciidoc/Transactions.adoc
@@ -331,15 +331,11 @@ If the transaction specified is a valid transaction, the transaction
 context is associated with the calling thread; otherwise, the thread is
 associated with no transaction.
 
-=== Transaction tobj = TransactionManager.suspend();
-
-=== 
-
-..
-
-=== TransactionManager.resume(tobj);
-
-=== 
+[source,java]
+----
+Transaction tobj = TransactionManager.suspend();
+TransactionManager.resume(tobj);
+----
 
 If _TransactionManager.resume_ __ is invoked
 when the calling thread is already associated with another transaction,

--- a/spec/src/main/asciidoc/Transactions.adoc
+++ b/spec/src/main/asciidoc/Transactions.adoc
@@ -28,8 +28,6 @@ consists of interfaces that are used to implement the transaction manager. For
 example, the Java mapping of the OTS are low-level interfaces used internally by
 a transaction manager.
 
-.
-
 === Background
 
 Distributed transaction services in

--- a/spec/src/main/asciidoc/Transactions.adoc
+++ b/spec/src/main/asciidoc/Transactions.adoc
@@ -1536,7 +1536,7 @@ _https://jakarta.ee/specifications/interceptors/2.0/_
 [appendix]
 == Revision History
 
-== Changes for Version 1.3
+=== Changes for Version 1.3
 
 * Remove the javax.transaction.xa types as they have been subsumed by
 Java SE.

--- a/spec/src/main/asciidoc/Transactions.adoc
+++ b/spec/src/main/asciidoc/Transactions.adoc
@@ -181,7 +181,9 @@ The following example illustrates how an
 application component acquires and uses a _UserTransaction_ object via
 injection.
 
-=== @Resource UserTransaction userTransaction;
+[source,java]
+----
+@Resource UserTransaction userTransaction;
 
 public void updateData() \{
 
@@ -197,7 +199,8 @@ public void updateData() \{
 
  userTransaction.commit();
 
-=== }
+}
+----
 
 
 
@@ -205,7 +208,9 @@ The following example illustrates how an
 application component acquires and uses a UserTransaction object using a
 JNDI lookup.
 
-=== public void updateData() \{
+[source,java]
+----
+public void updateData() \{
 
  // Obtain the default initial JNDI context.
 
@@ -230,7 +235,8 @@ JNDI lookup.
 
  userTransaction.commit();
 
-=== }
+}
+----
 
 The _UserTransaction.begin_ __ method starts
 a global transaction and associates the transaction with the calling
@@ -518,7 +524,9 @@ to compare two _Transaction_ objects when trying to reuse a resource
 that is already enlisted with a transaction. This can be done using the
 _equals_ method.
 
-=== Transaction txObj = TransactionManager.getTransaction();
+[source,java]
+----
+Transaction txObj = TransactionManager.getTransaction();
 
 Transaction someOtherTxObj = ...
 
@@ -526,7 +534,8 @@ Transaction someOtherTxObj = ...
 
 // ..
 
-=== boolean isSame = txObj.equals(someOtherTxObj);
+boolean isSame = txObj.equals(someOtherTxObj);
+----
 
 In addition, the transaction manager must
 implement the _Transaction_ object’s _hashCode_ method so that if two
@@ -827,7 +836,9 @@ transaction.
 The sample code below illustrates the above
 scenario:
 
-=== // Suppose we have some transactional connection-based
+[source,java]
+----
+// Suppose we have some transactional connection-based
 
 // resource r1 that is connected to an
 enterprise
@@ -870,6 +881,7 @@ status = xares.prepare(xid1);
 ..
 
 xares.commit(xid1, false);
+----
 
 === Local and Global Transactions
 
@@ -936,7 +948,9 @@ returns _true_ if the specified target object is connected to the same
 resource manager instance; otherwise, the method returns _false_ . The
 semi-pseudo code below illustrates the intended usage.
 
-=== public boolean enlistResource(XAResource xares)
+[source,java]
+----
+public boolean enlistResource(XAResource xares)
 
 \{ ..
 
@@ -987,7 +1001,8 @@ instance,
 
  ..
 
-=== }
+}
+----
 
 === Dynamic Registration
 
@@ -1158,24 +1173,31 @@ The following example will override behavior
 for application exceptions, causing the transaction to be marked for
 rollback for all application exceptions.
 
-=== @Transactional(rollbackOn=\{Exception.class})
+[source,java]
+----
+@Transactional(rollbackOn={Exception.class})
+----
 
 The following example will prevent
 transactions from being marked for rollback by the interceptor when an
 _IllegalStateException_ or any of its subclasses reaches the
 interceptor.
 
-=== @Transactional(
-
-===  dontRollbackOn=\{IllegalStateException.class})
+[source,java]
+----
+@Transactional(dontRollbackOn={IllegalStateException.class})
+----
 
 The following will cause the transaction to
 be marked for rollback for all runtime exceptions and all _SQLException_
 types except for _SQLWarning_ .
 
-=== @Transactional(rollbackOn=\{SQLException.class},
-
-===  dontRollbackOn=\{SQLWarning.class})
+[source,java]
+----
+@Transactional(
+        rollbackOn={SQLException.class},
+        dontRollbackOn={SQLWarning.class})
+----
 
 The _TransactionalException_ thrown from the
 _Transactional_ interceptors implementation is a _RuntimeException_ and
@@ -1199,19 +1221,16 @@ Jakarta EE specification . The transaction scope is active when the return
 from a call to _UserTransaction.getStatus_ or
 _TransactionManager.getStatus_ is one of the following states:
 
-=== Status.STATUS_ACTIVE
-
+[source,java]
+----
+Status.STATUS_ACTIVE
 Status.STATUS_MARKED_ROLLBACK
-
 Status.STATUS_PREPARED
-
 Status.STATUS_UNKNOWN
-
 Status.STATUS_PREPARING
-
 Status.STATUS_COMMITTING
-
-=== Status.STATUS_ROLLING_BACK
+Status.STATUS_ROLLING_BACK
+----
 
 It is not intended that the term “active” as
 defined here in relation to the _TransactionScoped_ annotation should
@@ -1239,7 +1258,9 @@ the expected behavior.
  _TransactionScoped_ annotated Jakarta Context Dependency Injection 3.0 managed
 bean:
 
-=== @TransactionScoped
+[source,java]
+----
+@TransactionScoped
 
  public class TestCDITransactionScopeBean \{
 
@@ -1251,30 +1272,13 @@ bean:
 
  }
 
-===  }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+}
+----
 
 Test Class: +
 
+[source,java]
+----
 @Inject
 
 UserTransaction userTransaction;
@@ -1337,8 +1341,7 @@ contextNotActiveException) \{
  // do nothing intentionally
 
  }
-
-=== 
+----
 
 == Jakarta Transactions Support in the Application Server
 
@@ -1401,11 +1404,11 @@ The code sample below illustrates how the
 application server obtains the _XAResource_ object reference and enlists
 it with the transaction manager.
 
-=== // Acquire some connection-based transactional resource to
+[source,java]
+----
+// Acquire some connection-based transactional resource to
 
 // access the resource manager
-
-=== 
 
 Context ctx = InitialContext();
 
@@ -1438,7 +1441,8 @@ Connection con =
 
 
 
-=== // return the connection to the application
+// return the connection to the application
+----
 
 === Transaction Association and Connection Request Flow
 


### PR DESCRIPTION
Closes #126 

* Removed 'CHAPTER' from headings and used titles, which were on the following line
* Cleaned up chapter and heading levels for consistency
* Marked appendices with `[appendix]`
* Where they were interfering with headings, code blocks were added
* Removed legacy wiki-style heading anchors
* Marked what looks like a broken table as a table to prevent it interfering with headings