### PR TITLE
Partial revert of f0c02aa58944ed58ae6409489fb532093bf5c2c6

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -39,20 +39,9 @@
         <jruby.version>9.2.6.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
+        <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
+        <revisiondate>${maven.build.timestamp}</revisiondate>
     </properties>
-
-    <scm>
-        <connection>scm:git:git@github.com:eclipse-ee4j/jakarta-transactions.git</connection>
-        <developerConnection>scm:git:git@github.com:eclipse-ee4j/jakarta-transactions.git</developerConnection>
-        <url>https://github.com/eclipse-ee4j/jakarta-transactions</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <distributionManagement>
-        <site>
-            <url>scm:git:git@github.com:eclipse-ee4j/jakarta-transactions.git</url>
-        </site>
-    </distributionManagement>
 
     <build>
         <defaultGoal>package</defaultGoal>


### PR DESCRIPTION
The scm information was added in the spec import but it's not actually correct (the repo name is wrong) and I am not sure how that tag is used but it looks like a Subversion reference anyway.

Also, removing that timestamping information means the build PDF and HTML spec documents don't have the date in some places that could be useful.