### PR TITLE
Fix copyright

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -243,7 +243,7 @@
                     <splitindex>true</splitindex>
                     <use>true</use>
                     <bottom>
-        <![CDATA[Copyright &#169; 2019 Eclipse Foundation. All Rights Reserved.
+        <![CDATA[Copyright &#169; 2018, 2020 Eclipse Foundation. All Rights Reserved.
             <br/>Use is subject to
     <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.
         ]]>

--- a/api/src/main/java/jakarta/transaction/HeuristicCommitException.java
+++ b/api/src/main/java/jakarta/transaction/HeuristicCommitException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/HeuristicMixedException.java
+++ b/api/src/main/java/jakarta/transaction/HeuristicMixedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/HeuristicRollbackException.java
+++ b/api/src/main/java/jakarta/transaction/HeuristicRollbackException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/InvalidTransactionException.java
+++ b/api/src/main/java/jakarta/transaction/InvalidTransactionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/NotSupportedException.java
+++ b/api/src/main/java/jakarta/transaction/NotSupportedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/RollbackException.java
+++ b/api/src/main/java/jakarta/transaction/RollbackException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/Status.java
+++ b/api/src/main/java/jakarta/transaction/Status.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/Synchronization.java
+++ b/api/src/main/java/jakarta/transaction/Synchronization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/SystemException.java
+++ b/api/src/main/java/jakarta/transaction/SystemException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/Transaction.java
+++ b/api/src/main/java/jakarta/transaction/Transaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/TransactionManager.java
+++ b/api/src/main/java/jakarta/transaction/TransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/TransactionRequiredException.java
+++ b/api/src/main/java/jakarta/transaction/TransactionRequiredException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/TransactionRolledbackException.java
+++ b/api/src/main/java/jakarta/transaction/TransactionRolledbackException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/TransactionScoped.java
+++ b/api/src/main/java/jakarta/transaction/TransactionScoped.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/TransactionSynchronizationRegistry.java
+++ b/api/src/main/java/jakarta/transaction/TransactionSynchronizationRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/Transactional.java
+++ b/api/src/main/java/jakarta/transaction/Transactional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/TransactionalException.java
+++ b/api/src/main/java/jakarta/transaction/TransactionalException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/UserTransaction.java
+++ b/api/src/main/java/jakarta/transaction/UserTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/transaction/package.html
+++ b/api/src/main/java/jakarta/transaction/package.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 
-    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/javadoc/doc-files/EFSL.html
+++ b/api/src/main/javadoc/doc-files/EFSL.html
@@ -20,7 +20,7 @@
   <li>All existing copyright notices, or if one does not exist, a notice
       (hypertext is preferred, but a textual representation is permitted)
       of the form: &quot;Copyright &copy; [$date-of-document]
-      &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
+      Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
       &quot;
   </li>
 </ul>
@@ -42,7 +42,7 @@
 
 <p>The notice is:</p>
 
-<p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
+<p>&quot;Copyright &copy; [$date-of-document] Eclipse Foundation. This software or
   document includes material copied from or derived from [title and URI
   of the Eclipse Foundation specification document].&quot;</p>
 

--- a/spec/src/main/asciidoc/Transactions.adoc
+++ b/spec/src/main/asciidoc/Transactions.adoc
@@ -1,11 +1,6 @@
 :sectnums:
 = Jakarta Transactions Specification, Version 2.0
 
-Copyright (c) 2020 Eclipse Foundation.
-
-Oracle and Java are registered trademarks of Oracle and/or its 
-affiliates. Other names may be trademarks of their respective owners. 
-
 == Introduction
 
 This document describes Jakarta

--- a/spec/src/main/asciidoc/license-efsl.adoc
+++ b/spec/src/main/asciidoc/license-efsl.adoc
@@ -9,7 +9,13 @@ Status: {revremark}
 Release: {revdate}
 ....
 
-Copyright (c) 2019 Eclipse Foundation.
+== Copyright
+
+Copyright (c) 2018, 2020 Eclipse Foundation.
+https://www.eclipse.org/legal/efsl.php[]
+
+Oracle and Java are registered trademarks of Oracle and/or its 
+affiliates. Other names may be trademarks of their respective owners. 
 
 === Eclipse Foundation Specification License
 
@@ -47,7 +53,7 @@ specification is expressly prohibited.
 
 The notice is:
 
-"Copyright (c) 2018 Eclipse Foundation. This software or
+"Copyright (c) [$date-of-document] Eclipse Foundation. This software or
 document includes material copied from or derived from [title and URI
 of the Eclipse Foundation specification document]."
 

--- a/spec/src/main/asciidoc/license-efsl.adoc
+++ b/spec/src/main/asciidoc/license-efsl.adoc
@@ -34,7 +34,7 @@ document, or portions thereof, that you use:
 * All existing copyright notices, or if one does not exist, a notice
   (hypertext is preferred, but a textual representation is permitted)
   of the form: "Copyright (c) [$date-of-document]
-  Eclipse Foundation, Inc. <<url to this license>>"
+  Eclipse Foundation, Inc. \<<url to this license>>"
 
 Inclusion of the full text of this NOTICE must be provided. We
 request that authorship attribution be provided in any software,


### PR DESCRIPTION
- Combine duplicate copyright notice into license-efsl.adoc
- Update copyright year in api project
- Fix EFSL license text to match original 