### PR TITLE
[#223, #227] place correct upper bound in Class types accepted by rollbackOn

### DIFF
--- a/api/src/main/java/jakarta/transaction/Recoverable.java
+++ b/api/src/main/java/jakarta/transaction/Recoverable.java
@@ -1,0 +1,28 @@
+package jakarta.transaction;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an unchecked exception type is recoverable,
+ * so that it does not result in the transaction being
+ * {@linkplain Transaction#setRollbackOnly marked for
+ * rollback} when thrown by a {@link Transactional}
+ * managed bean.
+ * <p>
+ * The annotated exception type must be a subclass of
+ * {@link RuntimeException}.
+ * <p>
+ * The effect of this annotation may be suppressed for
+ * a given managed bean by explicitly listing the
+ * exception type in {@link Transactional#rollbackOn}.
+ *
+ * @since JTA 2.1
+ */
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Recoverable {}

--- a/api/src/main/java/jakarta/transaction/Transactional.java
+++ b/api/src/main/java/jakarta/transaction/Transactional.java
@@ -135,27 +135,27 @@ public @interface Transactional {
     }
 
     /**
-     * The rollbackOn element can be set to indicate exceptions that must cause
-     *  the interceptor to mark the transaction for rollback. Conversely, the dontRollbackOn
+     * The {@code rollbackOn} element can be set to indicate exceptions that must cause the
+     *  interceptor to mark the transaction for rollback. Conversely, the {@link #dontRollbackOn}
      *  element can be set to indicate exceptions that must not cause the interceptor to mark
      *  the transaction for rollback. When a class is specified for either of these elements,
      *  the designated behavior applies to subclasses of that class as well. If both elements
-     *  are specified, dontRollbackOn takes precedence.
-     * @return Class[] of Exceptions
+     *  are specified, {@code rollbackOn} takes precedence.
+     * @return An array of exception types
      */
     @Nonbinding
-    public Class[] rollbackOn() default {};
+    Class<? extends Exception>[] rollbackOn() default {};
 
     /**
-     * The dontRollbackOn element can be set to indicate exceptions that must not cause
-     *  the interceptor to mark the transaction for rollback. Conversely, the rollbackOn element
-     *  can be set to indicate exceptions that must cause the interceptor to mark the transaction
-     *  for rollback. When a class is specified for either of these elements,
+     * The {@code dontRollbackOn} element can be set to indicate exceptions that must not cause
+     *  the interceptor to mark the transaction for rollback. Conversely, the {@link #rollbackOn}
+     *  element can be set to indicate exceptions that must cause the interceptor to mark the
+     *  transaction for rollback. When a class is specified for either of these elements,
      *  the designated behavior applies to subclasses of that class as well. If both elements
-     *  are specified, dontRollbackOn takes precedence.
-     * @return Class[] of Exceptions
+     *  are specified, {@code dontRollbackOn} takes precedence.
+     * @return An array of exception types
      */
     @Nonbinding
-    public Class[] dontRollbackOn() default {};
+    Class<? extends Exception>[] dontRollbackOn() default {};
 
 }

--- a/api/src/main/java/jakarta/transaction/Transactional.java
+++ b/api/src/main/java/jakarta/transaction/Transactional.java
@@ -144,7 +144,7 @@ public @interface Transactional {
      * @return An array of exception types
      */
     @Nonbinding
-    Class<? extends Exception>[] rollbackOn() default {};
+    Class<? extends Throwable>[] rollbackOn() default {};
 
     /**
      * The {@code dontRollbackOn} element can be set to indicate exceptions that must not cause
@@ -156,6 +156,6 @@ public @interface Transactional {
      * @return An array of exception types
      */
     @Nonbinding
-    Class<? extends Exception>[] dontRollbackOn() default {};
+    Class<? extends Throwable>[] dontRollbackOn() default {};
 
 }

--- a/spec/src/main/asciidoc/Transactions.adoc
+++ b/spec/src/main/asciidoc/Transactions.adoc
@@ -1071,18 +1071,29 @@ If called inside a transaction context, a
 `TransactionalException` with a nested `InvalidTransactionException`
 must be thrown
 
-By default checked exceptions do not result
-in the transactional interceptor marking the transaction for rollback
-and instances of `RuntimeException` and its subclasses do. This default
-behavior can be modified by specifying exceptions that result in the
-interceptor marking the transaction for rollback and/or exceptions that
-do not result in rollback. The `rollbackOn` element can be set to indicate
-exceptions that must cause the interceptor to mark the transaction for
-rollback. Conversely, the `dontRollbackOn` element can be set to
-indicate exceptions that must not cause the interceptor to mark the
-transaction for rollback. When a class is specified for either of these
-elements, the designated behavior applies to subclasses of that class as
-well. If both elements are specified, `dontRollbackOn` takes precedence.
+By default,
+
+- any unchecked exception--that is, any instance of `RuntimeException`
+  or of `Error`--causes the transactional interceptor to mark the
+  current transaction for rollback, but
+- a checked exception does not result in the transaction being marked
+  for rollback.
+
+This default behavior can be modified by explicitly specifying exception
+types that result in the interceptor marking the transaction for rollback
+and/or exception types that do not result in rollback.
+
+- The `rollbackOn` element can be set to indicate exceptions that must
+  cause the interceptor to mark the current transaction for rollback.
+- Conversely, the `dontRollbackOn` element can be set to indicate exceptions
+  that must not cause the interceptor to mark the transaction for rollback.
+
+When a class is specified for either of these elements, the designated
+behavior also applies to subclasses of that class. If an exception type
+is a subtype of a type listed by `rollbackOn`, and also a subtype of a
+type listed by `dontRollbackOn`, then `dontRollbackOn` takes precedence,
+and the exception type will not result in the transaction being marked
+for rollback.
 
 The following example will override behavior
 for application exceptions, causing the transaction to be marked for

--- a/spec/src/main/asciidoc/Transactions.adoc
+++ b/spec/src/main/asciidoc/Transactions.adoc
@@ -1073,11 +1073,14 @@ must be thrown
 
 By default,
 
-- any unchecked exception--that is, any instance of `RuntimeException`
-  or of `Error`--causes the transactional interceptor to mark the
-  current transaction for rollback, but
+- any unchecked exception -- that is, any instance of `RuntimeException`
+  or of `Error` -- which is not annotated `Recoverable` causes the
+  transactional interceptor to mark the current transaction for rollback,
+  but
 - a checked exception does not result in the transaction being marked
-  for rollback.
+  for rollback, and
+- similarly, an unchecked exception annotated `Recoverable` does not
+  result in the transaction being marked for rollback
 
 This default behavior can be modified by explicitly specifying exception
 types that result in the interceptor marking the transaction for rollback


### PR DESCRIPTION
~Assuming only `Exception` subtypes are allowed here.~ It's possible this assumption is incorrect.

for #223