### PR TITLE
[#225] introduce Transaction.Status enum and deprecate Status

### DIFF
--- a/api/src/main/java/jakarta/transaction/Status.java
+++ b/api/src/main/java/jakarta/transaction/Status.java
@@ -20,9 +20,11 @@ package jakarta.transaction;
  * The Status interface defines static variables used for transaction 
  * status codes.
  *
+ * @deprecated Use {@link Transaction.Status}.
+ *
  * @version Jakarta Transactions 2.0
  */
-
+@Deprecated(since = "2.1")
 public interface Status {
     /**
      * A transaction is associated with the target object and it is in the

--- a/api/src/main/java/jakarta/transaction/Status.java
+++ b/api/src/main/java/jakarta/transaction/Status.java
@@ -24,7 +24,7 @@ package jakarta.transaction;
  *
  * @version Jakarta Transactions 2.0
  */
-@Deprecated(since = "2.1")
+@Deprecated
 public interface Status {
     /**
      * A transaction is associated with the target object and it is in the

--- a/api/src/main/java/jakarta/transaction/Status.java
+++ b/api/src/main/java/jakarta/transaction/Status.java
@@ -16,6 +16,8 @@
 
 package jakarta.transaction;
 
+import static jakarta.transaction.Transaction.Status.*;
+
 /**
  * The Status interface defines static variables used for transaction 
  * status codes.
@@ -32,13 +34,13 @@ public interface Status {
      * transaction has been started and prior to a Coordinator issuing
      * any prepares, unless the transaction has been marked for rollback.
      */  
-    public final static int STATUS_ACTIVE = 0;
+    int STATUS_ACTIVE = 0;
 
     /**
      * A transaction is associated with the target object and it has been
      * marked for rollback, perhaps as a result of a setRollbackOnly operation.
      */  
-    public final static int STATUS_MARKED_ROLLBACK = 1;
+    int STATUS_MARKED_ROLLBACK = 1;
 
     /**
      * A transaction is associated with the target object and it has been
@@ -46,14 +48,14 @@ public interface Status {
      * target object may be waiting for instructions from a superior as to how
      * to proceed.
      */  
-    public final static int STATUS_PREPARED = 2;
+    int STATUS_PREPARED = 2;
  
     /**
      * A transaction is associated with the target object and it has been
      * committed. It is likely that heuristics exist; otherwise, the
      * transaction would have been destroyed and NoTransaction returned.
      */  
-    public final static int STATUS_COMMITTED = 3;
+    int STATUS_COMMITTED = 3;
 
     /**
      * A transaction is associated with the target object and the outcome
@@ -61,20 +63,20 @@ public interface Status {
      * otherwise, the transaction would have been destroyed and NoTransaction
      * returned.
      */  
-    public final static int STATUS_ROLLEDBACK = 4;
+    int STATUS_ROLLEDBACK = 4;
 
     /**
      * A transaction is associated with the target object but its
      * current status cannot be determined. This is a transient condition
      * and a subsequent invocation will ultimately return a different status.
      */  
-    public final static int STATUS_UNKNOWN = 5;
+    int STATUS_UNKNOWN = 5;
 
     /**
      * No transaction is currently associated with the target object. This
      * will occur after a transaction has completed.
      */  
-    public final static int STATUS_NO_TRANSACTION = 6;
+    int STATUS_NO_TRANSACTION = 6;
 
     /**
      * A transaction is associated with the target object and it is in the
@@ -84,7 +86,7 @@ public interface Status {
      * waiting for responses to prepare from one or more
      * Resources.
      */  
-    public final static int STATUS_PREPARING = 7;
+    int STATUS_PREPARING = 7;
 
     /**
      * A transaction is associated with the target object and it is in the
@@ -93,7 +95,7 @@ public interface Status {
      * This occurs because the implementation is probably waiting for 
      * responses from one or more Resources.
      */  
-    public final static int STATUS_COMMITTING = 8;
+    int STATUS_COMMITTING = 8;
 
     /**
      * A transaction is associated with the target object and it is in the
@@ -102,5 +104,45 @@ public interface Status {
      * The implementation is probably waiting for responses from one or more
      * Resources.
      */  
-    public final static int STATUS_ROLLING_BACK = 9;
+    int STATUS_ROLLING_BACK = 9;
+
+    /**
+     * The legacy integer-valued code equivalent to the given
+     * {@link jakarta.transaction.Status}.
+     */
+    static int code(Transaction.Status code) {
+        switch (code) {
+            case ACTIVE: return STATUS_ACTIVE;
+            case MARKED_FOR_ROLLBACK: return STATUS_MARKED_ROLLBACK;
+            case PREPARED: return STATUS_PREPARED;
+            case COMMITTED: return STATUS_COMMITTED;
+            case ROLLED_BACK: return STATUS_ROLLEDBACK;
+            case UNKNOWN: return STATUS_UNKNOWN;
+            case NO_TRANSACTION: return STATUS_NO_TRANSACTION;
+            case PREPARING: return STATUS_PREPARING;
+            case COMMITTING: return STATUS_COMMITTING;
+            case ROLLING_BACK: return STATUS_ROLLING_BACK;
+            default: throw new IllegalStateException(); // impossible
+        }
+    }
+
+    /**
+     * The {@link jakarta.transaction.Status} equivalent to the given
+     * legacy integer-valued code defined by this class.
+     */
+    static Transaction.Status status(int code) {
+        switch (code) {
+            case STATUS_ACTIVE: return ACTIVE;
+            case STATUS_MARKED_ROLLBACK: return MARKED_FOR_ROLLBACK;
+            case STATUS_PREPARED: return PREPARED;
+            case STATUS_COMMITTED: return COMMITTED;
+            case STATUS_ROLLEDBACK: return ROLLED_BACK;
+            case STATUS_UNKNOWN: return UNKNOWN;
+            case STATUS_NO_TRANSACTION: return NO_TRANSACTION;
+            case STATUS_PREPARING: return PREPARING;
+            case STATUS_COMMITTING: return COMMITTING;
+            case STATUS_ROLLING_BACK: return ROLLING_BACK;
+            default: throw new IllegalStateException(); // impossible
+        }
+    }
 }

--- a/api/src/main/java/jakarta/transaction/Synchronization.java
+++ b/api/src/main/java/jakarta/transaction/Synchronization.java
@@ -34,13 +34,28 @@ public interface Synchronization {
      * executed with the transaction context of the transaction that is being
      * committed.
      */
-    public void beforeCompletion();
+    default void beforeCompletion() {}
 
     /**
-     * This method is called by the transaction
-     * manager after the transaction is committed or rolled back.
+     * This method is called by the transaction manager after the
+     * transaction is committed or rolled back.
      *
      * @param status The status of the transaction completion.
+     *
+     * @since JTA 2.1
      */
-	public void afterCompletion(int status);
+    default void afterCompletion(Transaction.Status status) {}
+
+    /**
+     * This method is called by the transaction manager after the
+     * transaction is committed or rolled back, and after
+     * {@link #afterCompletion(Transaction.Status)} is called.
+     *
+     * @param status The status of the transaction completion.
+     *
+     * @deprecated Use {@link #afterCompletion(Transaction.Status)}
+     */
+    @Deprecated(since = "2.1")
+    default void afterCompletion(int status) {}
+
 }

--- a/api/src/main/java/jakarta/transaction/Synchronization.java
+++ b/api/src/main/java/jakarta/transaction/Synchronization.java
@@ -55,7 +55,7 @@ public interface Synchronization {
      *
      * @deprecated Use {@link #afterCompletion(Transaction.Status)}
      */
-    @Deprecated(since = "2.1")
+    @Deprecated
     default void afterCompletion(int status) {}
 
 }

--- a/api/src/main/java/jakarta/transaction/Synchronization.java
+++ b/api/src/main/java/jakarta/transaction/Synchronization.java
@@ -38,7 +38,11 @@ public interface Synchronization {
 
     /**
      * This method is called by the transaction manager after the
-     * transaction is committed or rolled back.
+     * transaction is committed or rolled back. An implementation
+     * of {@code Synchronization} may override both this method
+     * and its overload {@link #afterCompletion(Transaction.Status)}.
+     * Both overloads must be called by the transaction manager
+     * after the transaction completes.
      *
      * @param status The status of the transaction completion.
      *

--- a/api/src/main/java/jakarta/transaction/Transaction.java
+++ b/api/src/main/java/jakarta/transaction/Transaction.java
@@ -20,6 +20,8 @@ import javax.transaction.xa.XAResource;
 import java.lang.IllegalStateException;
 import java.lang.SecurityException;
 
+import static jakarta.transaction.Status.*;
+
 /**
  * The Transaction interface allows operations to be performed against
  * the transaction in the target Transaction object. A Transaction
@@ -108,6 +110,21 @@ public interface Transaction {
         SystemException;
 
     /**
+     * Obtain the status of the transaction associated with the target
+     * Transaction object.
+     *
+     * @return The transaction status. If no transaction is associated with
+     *    the target object, this method returns the
+     *    Status.NoTransaction value.
+     *
+     * @exception SystemException Thrown if the transaction manager
+     *    encounters an unexpected error condition.
+     *
+     * @since JTA 2.1
+     */
+    public Status getCurrentStatus() throws SystemException;
+
+    /**
      * Obtain the status of the transaction associated with the target 
      * Transaction object.
      *
@@ -118,7 +135,9 @@ public interface Transaction {
      * @exception SystemException Thrown if the transaction manager
      *    encounters an unexpected error condition.
      *
+     * @deprecated Use {@link #getCurrentStatus()}
      */
+    @Deprecated(since = "2.1")
     public int getStatus() throws SystemException;
 
     /**
@@ -173,5 +192,110 @@ public interface Transaction {
      */
     public void setRollbackOnly() throws IllegalStateException,
         SystemException;
+
+    /**
+     * Represents the status of a transaction.
+     *
+     * @since JTA 2.1
+     */
+    enum Status {
+        /**
+         * A transaction is associated with the target object, and it is in the
+         * active state. An implementation returns this status after a
+         * transaction has been started and prior to a Coordinator issuing
+         * any prepares, unless the transaction has been marked for rollback.
+         */
+        ACTIVE,
+
+        /**
+         * A transaction is associated with the target object, and it has been
+         * marked for rollback, perhaps as a result of a {@link #setRollbackOnly}
+         * operation.
+         */
+        MARKED_FOR_ROLLBACK,
+
+        /**
+         * A transaction is associated with the target object, and it has been
+         * prepared. That is, all subordinates have agreed to commit. The
+         * target object may be waiting for instructions from a superior as to
+         * how to proceed.
+         */
+        PREPARED,
+
+        /**
+         * A transaction is associated with the target object, and it has been
+         * committed. It is likely that heuristics exist; otherwise, the
+         * transaction would have been destroyed and {@link #NO_TRANSACTION}
+         * returned.
+         */
+        COMMITTED,
+
+        /**
+         * A transaction is associated with the target object and the outcome
+         * has been determined to be rollback. It is likely that heuristics
+         * exist; otherwise, the transaction would have been destroyed and
+         * {@link #NO_TRANSACTION} returned.
+         */
+        ROLLED_BACK,
+
+        /**
+         * A transaction is associated with the target object but its current
+         * status cannot be determined. This is a transient condition and a
+         * subsequent invocation will ultimately return a different status.
+         */
+        UNKNOWN,
+
+        /**
+         * No transaction is currently associated with the target object.
+         * This will occur after a transaction has completed.
+         */
+        NO_TRANSACTION,
+
+        /**
+         * A transaction is associated with the target object, and it is in
+         * the process of preparing. An implementation returns this status if
+         * it has started preparing, but has not yet completed the process.
+         * The likely reason for this is that the implementation is probably
+         * waiting for responses to prepare from one or more Resources.
+         */
+        PREPARING,
+
+        /**
+         * A transaction is associated with the target object, and it is in the
+         * process of committing. An implementation returns this status if it
+         * has decided to commit but has not yet completed the committing
+         * process. This occurs because the implementation is probably waiting
+         * for responses from one or more Resources.
+         */
+        COMMITTING,
+
+        /**
+         * A transaction is associated with the target object, and it is in the
+         * process of rolling back. An implementation returns this status if it
+         * has decided to rollback but has not yet completed the process. The
+         * implementation is probably waiting for responses from one or more
+         * Resources.
+         */
+        ROLLING_BACK;
+
+        /**
+         * The equivalent legacy integer-valued code defined by {@link jakarta.transaction.Status}.
+         */
+        public int code() {
+            switch (this) {
+                case ACTIVE: return STATUS_ACTIVE;
+                case MARKED_FOR_ROLLBACK: return STATUS_MARKED_ROLLBACK;
+                case PREPARED: return STATUS_PREPARED;
+                case COMMITTED: return STATUS_COMMITTED;
+                case ROLLED_BACK: return STATUS_ROLLEDBACK;
+                case UNKNOWN: return STATUS_UNKNOWN;
+                case NO_TRANSACTION: return STATUS_NO_TRANSACTION;
+                case PREPARING: return STATUS_PREPARING;
+                case COMMITTING: return STATUS_COMMITTING;
+                case ROLLING_BACK: return STATUS_ROLLING_BACK;
+                default: throw new IllegalStateException(); // impossible
+            }
+        }
+    }
 
 }

--- a/api/src/main/java/jakarta/transaction/Transaction.java
+++ b/api/src/main/java/jakarta/transaction/Transaction.java
@@ -137,7 +137,7 @@ public interface Transaction {
      *
      * @deprecated Use {@link #getCurrentStatus()}
      */
-    @Deprecated(since = "2.1")
+    @Deprecated
     public int getStatus() throws SystemException;
 
     /**

--- a/api/src/main/java/jakarta/transaction/Transaction.java
+++ b/api/src/main/java/jakarta/transaction/Transaction.java
@@ -20,8 +20,6 @@ import javax.transaction.xa.XAResource;
 import java.lang.IllegalStateException;
 import java.lang.SecurityException;
 
-import static jakarta.transaction.Status.*;
-
 /**
  * The Transaction interface allows operations to be performed against
  * the transaction in the target Transaction object. A Transaction
@@ -277,25 +275,6 @@ public interface Transaction {
          * Resources.
          */
         ROLLING_BACK;
-
-        /**
-         * The equivalent legacy integer-valued code defined by {@link jakarta.transaction.Status}.
-         */
-        public int code() {
-            switch (this) {
-                case ACTIVE: return STATUS_ACTIVE;
-                case MARKED_FOR_ROLLBACK: return STATUS_MARKED_ROLLBACK;
-                case PREPARED: return STATUS_PREPARED;
-                case COMMITTED: return STATUS_COMMITTED;
-                case ROLLED_BACK: return STATUS_ROLLEDBACK;
-                case UNKNOWN: return STATUS_UNKNOWN;
-                case NO_TRANSACTION: return STATUS_NO_TRANSACTION;
-                case PREPARING: return STATUS_PREPARING;
-                case COMMITTING: return STATUS_COMMITTING;
-                case ROLLING_BACK: return STATUS_ROLLING_BACK;
-                default: throw new IllegalStateException(); // impossible
-            }
-        }
     }
 
 }

--- a/api/src/main/java/jakarta/transaction/TransactionSynchronizationRegistry.java
+++ b/api/src/main/java/jakarta/transaction/TransactionSynchronizationRegistry.java
@@ -176,7 +176,7 @@ public interface TransactionSynchronizationRegistry {
      *
      * @deprecated Use {@link #getCurrentStatus()}
      */
-    @Deprecated(since = "2.1")
+    @Deprecated
     int getTransactionStatus();
 
     /**

--- a/api/src/main/java/jakarta/transaction/TransactionSynchronizationRegistry.java
+++ b/api/src/main/java/jakarta/transaction/TransactionSynchronizationRegistry.java
@@ -149,6 +149,20 @@ public interface TransactionSynchronizationRegistry {
     void registerInterposedSynchronization(Synchronization sync);
 
     /**
+     * Return the status of the transaction bound to the current thread
+     * at the time this method is called. This is the result of executing
+     * {@link TransactionManager#getStatus()} in the context of the
+     * transaction bound to the current thread at the time this method is
+     * called.
+     *
+     * @return the status of the transaction bound to the current thread
+     * at the time this method is called.
+     *
+     * @since JTA 2.1
+     */
+    Transaction.Status getCurrentStatus();
+
+    /**
      * Return the status of the transaction bound to the
      * current thread at the time this method is called.
      * This is the result of executing TransactionManager.getStatus() in
@@ -159,7 +173,10 @@ public interface TransactionSynchronizationRegistry {
      * at the time this method is called.
      *
      * @since JTA 1.1
+     *
+     * @deprecated Use {@link #getCurrentStatus()}
      */
+    @Deprecated(since = "2.1")
     int getTransactionStatus();
 
     /**

--- a/api/src/main/java/jakarta/transaction/UserTransaction.java
+++ b/api/src/main/java/jakarta/transaction/UserTransaction.java
@@ -125,7 +125,7 @@ public interface UserTransaction {
      *
      * @deprecated Use {@link #getCurrentStatus()}
      */
-    @Deprecated(since = "2.1")
+    @Deprecated
     int getStatus() throws SystemException;
 
     /**

--- a/api/src/main/java/jakarta/transaction/UserTransaction.java
+++ b/api/src/main/java/jakarta/transaction/UserTransaction.java
@@ -109,7 +109,23 @@ public interface UserTransaction {
      * @exception SystemException Thrown if the transaction manager
      *    encounters an unexpected error condition.
      *
+     * @since JTA 2.1
      */
+    Transaction.Status getCurrentStatus() throws SystemException;
+
+    /**
+     * Obtain the status of the transaction associated with the current thread.
+     *
+     * @return The transaction status. If no transaction is associated with
+     *    the current thread, this method returns the Status.NoTransaction
+     *    value.
+     *
+     * @exception SystemException Thrown if the transaction manager
+     *    encounters an unexpected error condition.
+     *
+     * @deprecated Use {@link #getCurrentStatus()}
+     */
+    @Deprecated(since = "2.1")
     int getStatus() throws SystemException;
 
     /**


### PR DESCRIPTION
also give `Synchronization` default noop impls of its methods

for #225