### PR TITLE
Define"Project Contribution Guidelines"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ https://www.eclipse.org/projects/handbook/#resources-commit
 ## Project Contribution Guidelines
 
  * Code should adhere to the style defined at https://github.com/eclipse-ee4j/ee4j.
- * Contributions should be made via github pull requests at https://github.com/eclipse-ee4j/servlet-api/pulls 
+ * Contributions should be made via github pull requests at https://github.com/jakartaee/transactions/pulls 
  * Authors of Pull Requests should seek review from committers outside of their own organisation and perspective.
  * Committers and Contributors may review any Pull Requests or Commits, even if not requested or assigned.
  * Pull Request by Committers that receive no review responses after a reasonable time, considering time zones and working days, can be interpreted as approved.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,19 @@ Contributor Agreement (ECA) on file.
 For more information, please see the Eclipse Committer Handbook:
 https://www.eclipse.org/projects/handbook/#resources-commit
 
+## Project Contribution Guidelines
+
+ * Code should adhere to the style defined at https://github.com/eclipse-ee4j/ee4j.
+ * Contributions should be made via github pull requests at https://github.com/eclipse-ee4j/servlet-api/pulls 
+ * Authors of Pull Requests should seek review from committers outside of their own organisation and perspective.
+ * Committers and Contributors may review any Pull Requests or Commits, even if not requested or assigned.
+ * Pull Request by Committers that receive no review responses after a reasonable time, considering time zones and working days, can be interpreted as approved.
+ * Pull Requests should pass continuous integration tests prior to merging.
+ * Pull Requests for significant contributions, new features or changed behaviour should be open for comment and review in a non draft state for at least 1 week prior to merging.
+ * In exceptional cases when a consensus on a Pull Request or Commit cannot be established through normal review and discussion, then any committer may request a formal consensus vote (ie. +1, 0, -1). Any such vote will be scheduled, conducted and adjudicated by the Project Leader(s).
+ * If the consensus for a merged Pull Request or commit is disputed, then it shall be considered reverted and consensus must be sought for it to remain rather than for it's reversion.
+ * In trivial or exceptional circumstances, these guidelines may be bypassed if the reasons for doing so are documented.
+
 ## Contact
 
 Contact the project developers via the project's "dev" list.


### PR DESCRIPTION
Taken from the servlet project and I think reflects the eventual https://github.com/jakartaee/servlet/pull/299

Includes more than https://github.com/jakartaee/transactions/issues/100 but does solve that as part of it.

Closes #100 (but includes more than that)