### PR TITLE
Clarify when the readOnly value goes into effect

### DIFF
--- a/api/src/main/java/jakarta/transaction/UserTransaction.java
+++ b/api/src/main/java/jakarta/transaction/UserTransaction.java
@@ -97,7 +97,8 @@ public interface UserTransaction {
     int getStatus() throws SystemException;
 
     /**
-     * Modify the timeout value that is associated with transactions started by the current thread with the begin method.
+     * Specifies the timeout value to be associated with transactions
+     * subsequently started by the current thread with the begin method.
      *
      * <p>
      * If an application has not called this method, the transaction service uses some default value for the transaction
@@ -112,7 +113,8 @@ public interface UserTransaction {
     void setTransactionTimeout(int seconds) throws SystemException;
 
     /**
-     * Modify the read-only value that is associated with transactions started by the current thread with the begin method.
+     * Specifies the read-only value to be associated with transactions
+     * subsequently started by the current thread with the begin method.
      *
      * <p>
      * If an application has not called this method, the transaction service uses the default value {@code false} for the


### PR DESCRIPTION
While reviewing #222 in order to learn about how this will integrate with the Jakarta Connector specification, I noticed ambiguous wording in the `setReadOnly` method Javadoc that makes it unclear whether the new read-only applies to a transaction that was just started on the thread or only to subsequent transactions that are started after that point.  I posted a [comment to the PR](https://github.com/jakartaee/transactions/pull/222/files#r2429779608).  The author replied to point out that the intended meaning is the latter, but indicated he had copied the pattern for the wording from the `setTransactionTimeout` method and would not be updating it under the PR (which was impossible anyway because the PR was already merged). Another participant asked me to submit a PR with proposed unambiguous wording for the methods. That is attempted under this PR.