### PR TITLE
XAResource needs ordering guarantees for setReadOnly

### DIFF
--- a/api/src/main/java/jakarta/transaction/xa/ExtendedXAResource.java
+++ b/api/src/main/java/jakarta/transaction/xa/ExtendedXAResource.java
@@ -33,6 +33,15 @@ public interface ExtendedXAResource extends XAResource {
      * returns <i>true</i>; otherwise <i>false</i>. If a resource manager does not support explicitly setting the
      * {@code XAResource} into read-only mode, this method returns <i>false</i>.
      *
+     * <p>
+     * The transaction manager must invoke this method <i>before</i> invoking
+     * {@link XAResource#start(Xid,int)} to indicate that the transaction with
+     * the respective {@code Xid} is requested to participate in a read-only
+     * transaction. The {@code setReadOnly} method must not be invoked while a
+     * transaction is active on the thread or after the respective transaction
+     * is suspended or completed.
+     * </p>
+     *
      * @param xid – A global transaction identifier for which this resource shall be set into read-only mode.
      *
      * @return <i>true</i> if the {@code XAResource} was put into read-only mode successfully; otherwise <i>false</i>.


### PR DESCRIPTION
While continuing to review the Transactions read-only feature for integration with the Jakarta Connector spec, I noticed a problem for XAResource/ExtendedXAResource implementations, which need more information about when they will need to handle `setReadOnly(xid)` being invoked.  This matters to the XAResource because some implementations will not be capable of changing the read-only behavior after the transaction has started.  See the [Connection.setReadOnly](https://docs.oracle.com/en/java/javase/25/docs/api/java.sql/java/sql/Connection.html#setReadOnly(boolean)) method of JDBC, which explicitly forbids changing read-only after a transaction has started.  ExtendedXAResource.setReadOnly should provide guarantees that it can only be validly invoked prior to XAResource.start so that the XAResource can know before starting the transaction what the read-only will be and will never need to handle it changing during the transaction.  I proposed a few sentences in the Javadoc to cover this.