### PR TITLE
Add readOnly tests to the tck

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -35,6 +35,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <jakarta.transaction-api.version>2.0.2-SNAPSHOT</jakarta.transaction-api.version>
     </properties>
 
     <dependencyManagement>
@@ -54,6 +55,7 @@
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
+            <version>${jakarta.transaction-api.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -94,6 +94,14 @@
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>whitebox</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>connector</artifactId>
+        </dependency>
         
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/Client.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/Client.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.jta.ee.readonlyxa;
+
+import com.sun.ts.tests.common.connector.util.ConnectorStatus;
+import com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase;
+import com.sun.ts.tests.jta.ee.transactional.Helper;
+import jakarta.annotation.Resource;
+import jakarta.inject.Inject;
+import jakarta.transaction.TransactionalException;
+import jakarta.transaction.UserTransaction;
+
+import static java.util.logging.Level.INFO;
+
+
+public class Client extends EJBLiteClientBase {
+
+	@Inject
+	ReadOnlyTestBean bean;
+
+	@Resource(lookup = "java:comp/UserTransaction")
+	private UserTransaction ut;
+
+	/*
+	 * Test that an insert can cause an exception when a resource is in read-only mode.
+	 * By default, read-only mode is supported on TSDataSource.
+	 */
+	public void testInsertWithReadOnlyXAResource() throws Exception {
+		String result = "TransactionalException not received";
+		try {
+			bean.setup();
+			try {
+				bean.insert();
+			} catch (TransactionalException te) {
+				if (te.getCause() instanceof RuntimeException ) {
+					result = "Received expected TransactionalException with nested RuntimeException";
+				} else {
+					throw new Exception("Received TransactionalException without nested RuntimeException");
+				}
+
+			} catch (Exception e) {
+				e.printStackTrace();
+				result = "Received unexcepted Exception :" + e.getMessage();
+			}
+		} finally {
+			bean.tearDown();
+		}
+
+		if (result.equals("Received expected TransactionalException with nested RuntimeException")) {
+			Helper.getLogger().log(INFO, result);
+			appendReason("Received expected TransactionalException with nested RuntimeException");
+		} else {
+			throw new Exception(result);
+		}
+	}
+
+	/*
+	 * Test that when TSDataSource does not support the read-only mode, that the insert will be ok.
+	 * Since the transaction is in read-only mode though, the JTA implementation must roll back the resource though,
+	 * so the lookup after the insert must fail.
+	 */
+	public void testInsertWithNonReadOnlyXAResource() throws Exception {
+		String result = "TransactionalException not received";
+		try {
+			ConnectorStatus.getConnectorStatus().setSupportReadOnly(false);
+			bean.setup();
+			bean.insert();
+			try {
+				bean.get();
+			} catch (TransactionalException te) {
+				if (te.getCause() instanceof RuntimeException ) {
+					result = "Received expected TransactionalException with nested RuntimeException";
+				} else {
+					throw new Exception("Received TransactionalException without nested RuntimeException");
+				}
+
+			} catch (Exception e) {
+				e.printStackTrace();
+				result = "Received unexcepted Exception :" + e.getMessage();
+			}
+		} finally {
+			bean.tearDown();
+			ConnectorStatus.getConnectorStatus().setSupportReadOnly(true);
+		}
+
+		if (result.equals("Received expected TransactionalException with nested RuntimeException")) {
+			Helper.getLogger().log(INFO, result);
+			appendReason("Received expected TransactionalException with nested RuntimeException");
+		} else {
+			throw new Exception(result);
+		}
+	}
+
+
+}

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/ClientServletTest.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/ClientServletTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.jta.ee.readonlyxa;
+
+import java.net.URL;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import com.sun.ts.tests.common.base.ServiceEETest;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("platform")
+@Tag("connector_resourcedef_servlet_optional")
+@Tag("tck-javatest")
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class ClientServletTest extends Client {
+    @TargetsContainer("tck-javatest")
+    @OverProtocol("javatest")
+    @Deployment(name = "servlet_resourcedefs", order = 2)
+    public static EnterpriseArchive createDeployment(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+        // War
+        // the war with the correct archive name
+        WebArchive servlet_resourcedefs_web = ShrinkWrap.create( WebArchive.class, "servlet_resourcedefs_web.war");
+        // The class files
+        servlet_resourcedefs_web.addClasses(
+                com.sun.ts.tests.connector.resourceDefs.servlet.Client.class
+        );
+        // The web.xml descriptor
+        URL warResURL = ClientServletTest.class.getResource( "servlet_resourcedefs_web.xml");
+        servlet_resourcedefs_web.addAsWebInfResource(warResURL, "web.xml");
+        // The sun-web.xml descriptor
+        warResURL = ClientServletTest.class.getResource( "servlet_resourcedefs_web.war.sun-web.xml");
+        servlet_resourcedefs_web.addAsWebInfResource(warResURL, "sun-web.xml");
+
+        // Call the archive processor
+        archiveProcessor.processWebArchive( servlet_resourcedefs_web, ClientServletTest.class, warResURL);
+
+        // RAR
+        // the rar with the correct archive name
+        JavaArchive conn_resourcedefs_jar = ShrinkWrap.create(JavaArchive.class, "resouredef.jar");
+        // The class files
+        conn_resourcedefs_jar.addClasses(
+                com.sun.ts.tests.common.connector.embedded.adapter1.CRDActivationSpec.class,
+                com.sun.ts.tests.common.connector.embedded.adapter1.CRDAdminObject.class,
+                com.sun.ts.tests.common.connector.embedded.adapter1.CRDManagedConnectionFactory.class,
+                com.sun.ts.tests.common.connector.embedded.adapter1.CRDMessageListener.class,
+                com.sun.ts.tests.common.connector.embedded.adapter1.CRDMessageWork.class,
+                com.sun.ts.tests.common.connector.embedded.adapter1.CRDResourceAdapterImpl.class,
+                com.sun.ts.tests.common.connector.embedded.adapter1.CRDWorkManager.class,
+                com.sun.ts.tests.common.connector.embedded.adapter1.MsgXAResource.class,
+                com.sun.ts.tests.common.connector.embedded.adapter1.NestedWorkXid1.ContextType.class,
+                com.sun.ts.tests.common.connector.embedded.adapter1.NestedWorkXid1.class,
+                com.sun.ts.tests.common.connector.util.ConnectorStatus.class,
+                com.sun.ts.tests.common.connector.util.Log.class,
+                com.sun.ts.tests.common.connector.whitebox.Debug.class,
+                com.sun.ts.tests.common.connector.whitebox.NestedWorkXid.class,
+                com.sun.ts.tests.common.connector.whitebox.TSConnectionFactory.class,
+                com.sun.ts.tests.common.connector.whitebox.TSDataSource.class,
+                com.sun.ts.tests.common.connector.whitebox.WorkImpl.class,
+                com.sun.ts.tests.common.connector.whitebox.WorkListenerImpl.class,
+                com.sun.ts.tests.common.connector.whitebox.XidImpl.class
+        );
+        JavaArchive conn_resourcedefs_rar = ShrinkWrap.create(JavaArchive.class, "whitebox-rd.rar");
+        conn_resourcedefs_rar.add(conn_resourcedefs_jar, "/", ZipExporter.class);
+
+        // Ear
+        EnterpriseArchive servlet_resourcedefs_ear = ShrinkWrap.create(EnterpriseArchive.class, "servlet_resourcedefs.ear");
+
+        // Any libraries added to the ear
+
+        // The component jars built by the package target
+        servlet_resourcedefs_ear.addAsModule(servlet_resourcedefs_web);
+        servlet_resourcedefs_ear.addAsModule(conn_resourcedefs_rar);
+
+
+
+
+        // The application.xml descriptor
+        URL earResURL = null;
+        // The sun-application.xml descriptor
+        earResURL = ClientServletTest.class.getResource( "servlet_resourcedefs.ear.sun-application.xml");
+        servlet_resourcedefs_ear.addAsManifestResource(earResURL, "sun-application.xml");
+        // Call the archive processor
+        archiveProcessor.processEarArchive( servlet_resourcedefs_ear, ClientServletTest.class, earResURL);
+        return servlet_resourcedefs_ear;
+    }
+
+    @Test
+    @Override
+    public void testInsertWithReadOnlyXAResource() throws Exception {
+        super.testInsertWithReadOnlyXAResource();
+    }
+
+    @Test
+    @Override
+    public void testInsertWithNonReadOnlyXAResource() throws Exception {
+        super.testInsertWithNonReadOnlyXAResource();
+    }
+}

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/ReadOnlyTestBean.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/ReadOnlyTestBean.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.jta.ee.readonlyxa;
+
+import com.sun.ts.tests.common.connector.whitebox.TSConnection;
+import com.sun.ts.tests.common.connector.whitebox.TSDataSource;
+import jakarta.annotation.Resource;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
+
+public class ReadOnlyTestBean {
+    public static final String NAME = "read-only-test-bean";
+
+    @Resource(lookup = "java:comp/env/eis/whitebox-tx")
+    private TSDataSource ds;
+
+    public ReadOnlyTestBean() {
+    }
+
+    public String getName() {
+        return NAME;
+    }
+
+	@Transactional
+	public void setup() {
+		try {
+			TSConnection connection = ds.getConnection();
+			connection.dropTable();
+			connection.insert( "2", "Hello" );
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Transactional
+	public void tearDown() {
+		try {
+			ds.getConnection().dropTable();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+    @Transactional(value = TxType.REQUIRED, readOnly = true)
+    public void insert() {
+		try {
+			ds.getConnection().insert("1", "Hello");
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+    @Transactional(value = TxType.REQUIRED, readOnly = true)
+    public String get() {
+        try {
+            return ds.getConnection().readValue("1");
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/ReadOnlyTestBean.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/ReadOnlyTestBean.java
@@ -57,7 +57,7 @@ public class ReadOnlyTestBean {
 		}
 	}
 
-    @Transactional(value = TxType.REQUIRED, readOnly = true)
+    @Transactional(value = TxType.REQUIRED, isReadOnly = true)
     public void insert() {
 		try {
 			ds.getConnection().insert("1", "Hello");
@@ -67,7 +67,7 @@ public class ReadOnlyTestBean {
 		}
 	}
 
-    @Transactional(value = TxType.REQUIRED, readOnly = true)
+    @Transactional(value = TxType.REQUIRED, isReadOnly = true)
     public String get() {
         try {
             return ds.getConnection().readValue("1");

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/servlet_resourcedefs.ear.sun-application.xml
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/servlet_resourcedefs.ear.sun-application.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-application PUBLIC "-//Sun Microsystems, Inc.//DTD Sun ONE Application Server 8.0 J2EE Application 1.4//EN" "http://www.sun.com/software/sunone/appserver/dtds/sun-application_1_4-0.dtd">
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-application>
+  <web>
+    <web-uri>servlet_resourcedefs_web.war</web-uri>
+    <context-root>servlet_resourcedefs_web</context-root>
+  </web>
+  <unique-id>0</unique-id>
+  <security-role-mapping>
+    <role-name>Administrator</role-name>
+    <principal-name>j2ee</principal-name>
+  </security-role-mapping>
+  <security-role-mapping>
+    <role-name>Manager</role-name>
+    <principal-name>javajoe</principal-name>
+  </security-role-mapping>
+  <security-role-mapping>
+    <role-name>Employee</role-name>
+    <principal-name>javajoe</principal-name>
+    <principal-name>j2ee</principal-name>
+  </security-role-mapping>
+</sun-application>

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/servlet_resourcedefs_web.war.sun-web.xml
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/servlet_resourcedefs_web.war.sun-web.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-web-app PUBLIC "-//Sun Microsystems, Inc.//DTD GlassFish Application Server 3.0 Servlet 3.0//EN" "http://www.sun.com/software/appserver/dtds/sun-web-app_3_0-0.dtd">
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-web-app>
+ <security-role-mapping>
+    <role-name>Administrator</role-name>
+    <principal-name>j2ee</principal-name>
+  </security-role-mapping>
+ <security-role-mapping>
+    <role-name>Manager</role-name>
+    <principal-name>javajoe</principal-name>
+  </security-role-mapping>
+  <security-role-mapping>
+    <role-name>Employee</role-name>
+    <principal-name>javajoe</principal-name>
+    <principal-name>j2ee</principal-name>
+  </security-role-mapping>
+</sun-web-app>

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/servlet_resourcedefs_web.xml
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/readonlyxa/servlet_resourcedefs_web.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5.0" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+  <display-name>servlet_resourcedefs_web</display-name>
+  <resource-ref>
+    <res-ref-name>whitebox-rd</res-ref-name>
+    <res-type>com.sun.ts.tests.common.connector.whitebox.TSConnectionFactory</res-type>
+    <res-auth>Container</res-auth>
+    <res-sharing-scope>Shareable</res-sharing-scope>
+  </resource-ref>
+  <login-config>
+    <auth-method>BASIC</auth-method>
+    <realm-name>default</realm-name>
+  </login-config>
+</web-app>

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/Client.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/Client.java
@@ -58,6 +58,106 @@ public class Client extends EJBLiteClientBase {
     TwoManagedBean two;
 
     /*
+     * @testName: txTypeRequiredReadOnly_withoutTransaction
+     *
+     * @test_Strategy: readOnly: If called inside a read-only transaction context, the managed bean method execution
+     *  must then continue inside this transaction context.
+     *  A read-only transaction may only run in a read-only transaction context, and similarly,
+     *  a non-read-only transaction may only run in a non-read-only transaction context. As defined by the semantics
+     *  of the configured {@code TxType}, a newly started transaction must be read-only if the {@code readOnly} element
+     *  is {@code true}, and be non-read-only if the {@code readOnly} element is {@code false}.
+     */
+    public void txTypeRequiredReadOnly_withoutTransaction() throws Exception {
+        Helper.assertEquals( "\n", "readOnly", one.txTypeRequiredReadOnly(), callRecords);
+        appendReason(Helper.compareResult("readOnly", one.txTypeRequiredReadOnly()));
+
+    }
+
+    /*
+     * @testName: txTypeRequiredReadOnly_withReadOnlyTransaction
+     *
+     * @test_Strategy: readOnly: If called inside a read-only transaction context, the managed bean method execution
+     *  must then continue inside this transaction context.
+     *  A read-only transaction may only run in a read-only transaction context, and similarly,
+     *  a non-read-only transaction may only run in a non-read-only transaction context. As defined by the semantics
+     *  of the configured {@code TxType}, a newly started transaction must be read-only if the {@code readOnly} element
+     *  is {@code true}, and be non-read-only if the {@code readOnly} element is {@code false}.
+     */
+    public void txTypeRequiredReadOnly_withReadOnlyTransaction() throws Exception {
+        try {
+            ut.setReadOnly(true);
+            ut.begin();
+            Helper.assertEquals( null, "readOnly", one.txTypeRequiredReadOnly(), callRecords);
+            appendReason(Helper.compareResult("readOnly", one.txTypeRequiredReadOnly()));
+            ut.commit();
+        } catch (Exception e) {
+            Helper.getLogger().log(INFO, null, e);
+            throw new Exception("txTypeRequiredReadOnly_withReadOnlyTransaction failed");
+        } finally {
+            ut.setReadOnly(false);
+        }
+    }
+
+    /*
+     * @testName: txTypeRequiredReadOnly_withNonReadOnlyTransaction
+     *
+     * @test_Strategy: readOnly: If called inside a read-only transaction context, the managed bean method execution
+     *  must then continue inside this transaction context.
+     *  A read-only transaction may only run in a read-only transaction context, and similarly,
+     *  a non-read-only transaction may only run in a non-read-only transaction context. As defined by the semantics
+     *  of the configured {@code TxType}, a newly started transaction must be read-only if the {@code readOnly} element
+     *  is {@code true}, and be non-read-only if the {@code readOnly} element is {@code false}.
+     */
+    public void txTypeRequiredReadOnly_withNonReadOnlyTransaction() throws Exception {
+        String result = "TransactionalException not received";
+
+        try {
+            ut.begin();
+            Helper.getLogger().info("Invoking OneManagedBean.txTypeRequiredReadOnly() with a non-read-only transaction Context");
+            one.txTypeRequiredReadOnly();
+        } catch (TransactionalException te) {
+            if (te.getCause() instanceof InvalidTransactionException) {
+                result = "Received expected TransactionalException with nested InvalidTransactionException";
+            } else {
+                throw new Exception("Received TransactionalException without nested InvalidTransactionException");
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            result = "Received unexcepted Exception :" + e.getMessage();
+        }
+
+        if (result.equals("Received expected TransactionalException with nested InvalidTransactionException")) {
+            Helper.getLogger().log(INFO, result);
+            appendReason("Received expected TransactionalException with nested InvalidTransactionException");
+        } else {
+            throw new Exception(result);
+        }
+    }
+
+    /*
+     * @testName: txTypeRequiresNewReadOnly_withNonReadOnlyTransaction
+     *
+     * @test_Strategy: readOnly: If called inside a read-only transaction context, the managed bean method execution
+     *  must then continue inside this transaction context.
+     *  A read-only transaction may only run in a read-only transaction context, and similarly,
+     *  a non-read-only transaction may only run in a non-read-only transaction context. As defined by the semantics
+     *  of the configured {@code TxType}, a newly started transaction must be read-only if the {@code readOnly} element
+     *  is {@code true}, and be non-read-only if the {@code readOnly} element is {@code false}.
+     */
+    public void txTypeRequiresNewReadOnly_withNonReadOnlyTransaction() throws Exception {
+        try {
+            ut.begin();
+            Helper.assertEquals( null, "readOnly", one.txTypeRequiresNewReadOnly(), callRecords);
+            appendReason(Helper.compareResult("readOnly", one.txTypeRequiresNewReadOnly()));
+            ut.commit();
+        } catch (Exception e) {
+            Helper.getLogger().log(INFO, null, e);
+            throw new Exception("txTypeRequiresNewReadOnly_withNonReadOnlyTransaction failed");
+        }
+    }
+
+    /*
      * @testName: txTypeRequired_withoutTransaction
      *
      * @test_Strategy: TxType.REQUIRED: If called outside a transaction context, the interceptor must begin a new JTA

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/Client.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/Client.java
@@ -23,6 +23,7 @@ import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.inject.Inject;
 import jakarta.interceptor.Interceptor;
 import jakarta.transaction.InvalidTransactionException;
+import jakarta.transaction.RollbackException;
 import jakarta.transaction.Status;
 import jakarta.transaction.SystemException;
 import jakarta.transaction.TransactionRequiredException;
@@ -84,15 +85,29 @@ public class Client extends EJBLiteClientBase {
      *  is {@code true}, and be non-read-only if the {@code readOnly} element is {@code false}.
      */
     public void txTypeRequiredReadOnly_withReadOnlyTransaction() throws Exception {
+        boolean gotRollbackException = false;
+
         try {
             ut.begin(true);
             Helper.assertEquals( null, "readOnly", one.txTypeRequiredReadOnly(), callRecords);
             appendReason(Helper.compareResult("readOnly", one.txTypeRequiredReadOnly()));
-            ut.commit();
+            // A read-only transaction's only permitted outcome is to roll back:
+            // commit() must roll the transaction back and throw RollbackException.
+            try {
+                ut.commit();
+            } catch (RollbackException e) {
+                gotRollbackException = true;
+            }
         } catch (Exception e) {
             Helper.getLogger().log(INFO, null, e);
             throw new Exception("txTypeRequiredReadOnly_withReadOnlyTransaction failed");
         }
+
+        if (!gotRollbackException) {
+            throw new Exception("txTypeRequiredReadOnly_withReadOnlyTransaction failed: "
+                    + "expected RollbackException from commit() of a read-only transaction");
+        }
+        appendReason("Got expected RollbackException from commit() of a read-only transaction");
     }
 
     /*

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/Client.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/Client.java
@@ -85,16 +85,13 @@ public class Client extends EJBLiteClientBase {
      */
     public void txTypeRequiredReadOnly_withReadOnlyTransaction() throws Exception {
         try {
-            ut.setReadOnly(true);
-            ut.begin();
+            ut.begin(true);
             Helper.assertEquals( null, "readOnly", one.txTypeRequiredReadOnly(), callRecords);
             appendReason(Helper.compareResult("readOnly", one.txTypeRequiredReadOnly()));
             ut.commit();
         } catch (Exception e) {
             Helper.getLogger().log(INFO, null, e);
             throw new Exception("txTypeRequiredReadOnly_withReadOnlyTransaction failed");
-        } finally {
-            ut.setReadOnly(false);
         }
     }
 

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/ClientEjblitejsfTest.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/ClientEjblitejsfTest.java
@@ -137,6 +137,114 @@ public class ClientEjblitejsfTest extends EJBLiteJsfClientBase implements Serial
     }
 
     /*
+     * @testName: txTypeRequiredReadOnly_withoutTransaction
+     *
+     * @test_Strategy: readOnly: If called inside a read-only transaction context, the managed bean method execution
+     *  must then continue inside this transaction context.
+     *  A read-only transaction may only run in a read-only transaction context, and similarly,
+     *  a non-read-only transaction may only run in a non-read-only transaction context. As defined by the semantics
+     *  of the configured {@code TxType}, a newly started transaction must be read-only if the {@code readOnly} element
+     *  is {@code true}, and be non-read-only if the {@code readOnly} element is {@code false}.
+     */
+    @Test
+    @TargetVehicle("ejblitejsf")
+    public void txTypeRequiredReadOnly_withoutTransaction() throws Exception {
+        Helper.assertEquals( "\n", "readOnly", one.txTypeRequiredReadOnly(), callRecords);
+        appendReason(Helper.compareResult("readOnly", one.txTypeRequiredReadOnly()));
+
+    }
+
+    /*
+     * @testName: txTypeRequiredReadOnly_withReadOnlyTransaction
+     *
+     * @test_Strategy: readOnly: If called inside a read-only transaction context, the managed bean method execution
+     *  must then continue inside this transaction context.
+     *  A read-only transaction may only run in a read-only transaction context, and similarly,
+     *  a non-read-only transaction may only run in a non-read-only transaction context. As defined by the semantics
+     *  of the configured {@code TxType}, a newly started transaction must be read-only if the {@code readOnly} element
+     *  is {@code true}, and be non-read-only if the {@code readOnly} element is {@code false}.
+     */
+    @Test
+    @TargetVehicle("ejblitejsf")
+    public void txTypeRequiredReadOnly_withReadOnlyTransaction() throws Exception {
+        try {
+            ut.setReadOnly(true);
+            ut.begin();
+            Helper.assertEquals( null, "readOnly", one.txTypeRequiredReadOnly(), callRecords);
+            appendReason(Helper.compareResult("readOnly", one.txTypeRequiredReadOnly()));
+            ut.commit();
+        } catch (Exception e) {
+            Helper.getLogger().log( Level.INFO, null, e);
+            throw new Exception("txTypeRequiredReadOnly_withReadOnlyTransaction failed");
+        } finally {
+            ut.setReadOnly(false);
+        }
+    }
+
+    /*
+     * @testName: txTypeRequiredReadOnly_withNonReadOnlyTransaction
+     *
+     * @test_Strategy: readOnly: If called inside a read-only transaction context, the managed bean method execution
+     *  must then continue inside this transaction context.
+     *  A read-only transaction may only run in a read-only transaction context, and similarly,
+     *  a non-read-only transaction may only run in a non-read-only transaction context. As defined by the semantics
+     *  of the configured {@code TxType}, a newly started transaction must be read-only if the {@code readOnly} element
+     *  is {@code true}, and be non-read-only if the {@code readOnly} element is {@code false}.
+     */
+    @Test
+    @TargetVehicle("ejblitejsf")
+    public void txTypeRequiredReadOnly_withNonReadOnlyTransaction() throws Exception {
+        String result = "TransactionalException not received";
+
+        try {
+            ut.begin();
+            Helper.getLogger().info("Invoking OneManagedBean.txTypeRequiredReadOnly() with a non-read-only transaction Context");
+            one.txTypeRequiredReadOnly();
+        } catch (TransactionalException te) {
+            if (te.getCause() instanceof InvalidTransactionException) {
+                result = "Received expected TransactionalException with nested InvalidTransactionException";
+            } else {
+                throw new Exception("Received TransactionalException without nested InvalidTransactionException");
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            result = "Received unexcepted Exception :" + e.getMessage();
+        }
+
+        if (result.equals("Received expected TransactionalException with nested InvalidTransactionException")) {
+            Helper.getLogger().log( Level.INFO, result);
+            appendReason("Received expected TransactionalException with nested InvalidTransactionException");
+        } else {
+            throw new Exception(result);
+        }
+    }
+
+    /*
+     * @testName: txTypeRequiresNewReadOnly_withNonReadOnlyTransaction
+     *
+     * @test_Strategy: readOnly: If called inside a read-only transaction context, the managed bean method execution
+     *  must then continue inside this transaction context.
+     *  A read-only transaction may only run in a read-only transaction context, and similarly,
+     *  a non-read-only transaction may only run in a non-read-only transaction context. As defined by the semantics
+     *  of the configured {@code TxType}, a newly started transaction must be read-only if the {@code readOnly} element
+     *  is {@code true}, and be non-read-only if the {@code readOnly} element is {@code false}.
+     */
+    @Test
+    @TargetVehicle("ejblitejsf")
+    public void txTypeRequiresNewReadOnly_withNonReadOnlyTransaction() throws Exception {
+        try {
+            ut.begin();
+            Helper.assertEquals( null, "readOnly", one.txTypeRequiresNewReadOnly(), callRecords);
+            appendReason(Helper.compareResult("readOnly", one.txTypeRequiresNewReadOnly()));
+            ut.commit();
+        } catch (Exception e) {
+            Helper.getLogger().log( Level.INFO, null, e);
+            throw new Exception("txTypeRequiresNewReadOnly_withNonReadOnlyTransaction failed");
+        }
+    }
+
+    /*
      * @testName: txTypeRequired_withoutTransaction
      *
      * @test_Strategy: TxType.REQUIRED: If called outside a transaction context, the interceptor must begin a new JTA

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/ClientEjblitejsfTest.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/ClientEjblitejsfTest.java
@@ -10,6 +10,7 @@ import jakarta.annotation.Resource;
 import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.inject.Inject;
 import jakarta.transaction.InvalidTransactionException;
+import jakarta.transaction.RollbackException;
 import jakarta.transaction.Status;
 import jakarta.transaction.SystemException;
 import jakarta.transaction.TransactionRequiredException;
@@ -167,15 +168,29 @@ public class ClientEjblitejsfTest extends EJBLiteJsfClientBase implements Serial
     @Test
     @TargetVehicle("ejblitejsf")
     public void txTypeRequiredReadOnly_withReadOnlyTransaction() throws Exception {
+        boolean gotRollbackException = false;
+
         try {
             ut.begin(true);
             Helper.assertEquals( null, "readOnly", one.txTypeRequiredReadOnly(), callRecords);
             appendReason(Helper.compareResult("readOnly", one.txTypeRequiredReadOnly()));
-            ut.commit();
+            // A read-only transaction's only permitted outcome is to roll back:
+            // commit() must roll the transaction back and throw RollbackException.
+            try {
+                ut.commit();
+            } catch (RollbackException e) {
+                gotRollbackException = true;
+            }
         } catch (Exception e) {
             Helper.getLogger().log( Level.INFO, null, e);
             throw new Exception("txTypeRequiredReadOnly_withReadOnlyTransaction failed");
         }
+
+        if (!gotRollbackException) {
+            throw new Exception("txTypeRequiredReadOnly_withReadOnlyTransaction failed: "
+                    + "expected RollbackException from commit() of a read-only transaction");
+        }
+        appendReason("Got expected RollbackException from commit() of a read-only transaction");
     }
 
     /*

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/ClientEjblitejsfTest.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/ClientEjblitejsfTest.java
@@ -168,16 +168,13 @@ public class ClientEjblitejsfTest extends EJBLiteJsfClientBase implements Serial
     @TargetVehicle("ejblitejsf")
     public void txTypeRequiredReadOnly_withReadOnlyTransaction() throws Exception {
         try {
-            ut.setReadOnly(true);
-            ut.begin();
+            ut.begin(true);
             Helper.assertEquals( null, "readOnly", one.txTypeRequiredReadOnly(), callRecords);
             appendReason(Helper.compareResult("readOnly", one.txTypeRequiredReadOnly()));
             ut.commit();
         } catch (Exception e) {
             Helper.getLogger().log( Level.INFO, null, e);
             throw new Exception("txTypeRequiredReadOnly_withReadOnlyTransaction failed");
-        } finally {
-            ut.setReadOnly(false);
         }
     }
 

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/ClientEjblitejspTest.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/ClientEjblitejspTest.java
@@ -91,6 +91,33 @@ public class ClientEjblitejspTest extends com.sun.ts.tests.jta.ee.transactional.
         return transactional_ejblitejsp_vehicle_web;
     }
 
+    @Test
+    @Override
+    @TargetVehicle("ejblitejsp")
+    public void txTypeRequiredReadOnly_withoutTransaction() throws Exception {
+        super.txTypeRequiredReadOnly_withoutTransaction();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("ejblitejsp")
+    public void txTypeRequiredReadOnly_withReadOnlyTransaction() throws Exception {
+        super.txTypeRequiredReadOnly_withReadOnlyTransaction();
+    }
+    @Test
+    @Override
+    @TargetVehicle("ejblitejsp")
+    public void txTypeRequiredReadOnly_withNonReadOnlyTransaction() throws Exception {
+        super.txTypeRequiredReadOnly_withNonReadOnlyTransaction();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("ejblitejsp")
+    public void txTypeRequiresNewReadOnly_withNonReadOnlyTransaction() throws Exception {
+        super.txTypeRequiresNewReadOnly_withNonReadOnlyTransaction();
+    }
+
     /*
      * @testName: txTypeRequired_withoutTransaction
      *

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/ClientEjbliteservlet2Test.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/ClientEjbliteservlet2Test.java
@@ -96,6 +96,34 @@ public class ClientEjbliteservlet2Test extends com.sun.ts.tests.jta.ee.transacti
         return transactional_ejbliteservlet2_vehicle_web;
     }
 
+    @Test
+    @Override
+    @TargetVehicle("ejbliteservlet2")
+    public void txTypeRequiredReadOnly_withoutTransaction() throws Exception {
+        super.txTypeRequiredReadOnly_withoutTransaction();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("ejbliteservlet2")
+    public void txTypeRequiredReadOnly_withReadOnlyTransaction() throws Exception {
+        super.txTypeRequiredReadOnly_withReadOnlyTransaction();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("ejbliteservlet2")
+    public void txTypeRequiredReadOnly_withNonReadOnlyTransaction() throws Exception {
+        super.txTypeRequiredReadOnly_withNonReadOnlyTransaction();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("ejbliteservlet2")
+    public void txTypeRequiresNewReadOnly_withNonReadOnlyTransaction() throws Exception {
+        super.txTypeRequiresNewReadOnly_withNonReadOnlyTransaction();
+    }
+
     /*
      * @testName: txTypeRequired_withoutTransaction
      *

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/ClientEjbliteservletTest.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/ClientEjbliteservletTest.java
@@ -92,6 +92,34 @@ public class ClientEjbliteservletTest extends com.sun.ts.tests.jta.ee.transactio
         return transactional_ejbliteservlet_vehicle_web;
     }
 
+    @Test
+    @Override
+    @TargetVehicle("ejbliteservlet")
+    public void txTypeRequiredReadOnly_withoutTransaction() throws Exception {
+        super.txTypeRequiredReadOnly_withoutTransaction();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("ejbliteservlet")
+    public void txTypeRequiredReadOnly_withReadOnlyTransaction() throws Exception {
+        super.txTypeRequiredReadOnly_withReadOnlyTransaction();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("ejbliteservlet")
+    public void txTypeRequiredReadOnly_withNonReadOnlyTransaction() throws Exception {
+        super.txTypeRequiredReadOnly_withNonReadOnlyTransaction();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("ejbliteservlet")
+    public void txTypeRequiresNewReadOnly_withNonReadOnlyTransaction() throws Exception {
+        super.txTypeRequiresNewReadOnly_withNonReadOnlyTransaction();
+    }
+
     /*
      * @testName: txTypeRequired_withoutTransaction
      *

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/OneManagedBean.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/OneManagedBean.java
@@ -21,6 +21,7 @@ import jakarta.annotation.Resource;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.InterceptionType;
 import jakarta.inject.Inject;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import jakarta.transaction.Transactional;
 import jakarta.transaction.Transactional.TxType;
 import jakarta.transaction.UserTransaction;
@@ -38,6 +39,9 @@ public class OneManagedBean {
     @Resource(lookup = "java:comp/UserTransaction")
     private UserTransaction ut2;
 
+    @Resource
+    private TransactionSynchronizationRegistry tsr;
+
     @Inject
     BeanManager beanManager;
 
@@ -52,6 +56,42 @@ public class OneManagedBean {
     }
 
     public OneManagedBean() {
+    }
+
+    @Transactional(value = TxType.REQUIRED, readOnly = true)
+    public String txTypeRequiredReadOnly() {
+        String result = "not readOnly";
+        if (tsr.isReadOnly()) {
+            result = "readOnly";
+        }
+        return result;
+    }
+
+    @Transactional(value = TxType.REQUIRES_NEW, readOnly = true)
+    public String txTypeRequiresNewReadOnly() {
+        String result = "not readOnly";
+        if (tsr.isReadOnly()) {
+            result = "readOnly";
+        }
+        return result;
+    }
+
+    @Transactional(value = TxType.REQUIRED)
+    public String txTypeRequiredNonReadOnly() {
+        String result = "not readOnly";
+        if (tsr.isReadOnly()) {
+            result = "readOnly";
+        }
+        return result;
+    }
+
+    @Transactional(value = TxType.REQUIRES_NEW)
+    public String txTypeRequiresNewNonReadOnly() {
+        String result = "not readOnly";
+        if (tsr.isReadOnly()) {
+            result = "readOnly";
+        }
+        return result;
     }
 
     @Transactional(value = TxType.REQUIRED)

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/OneManagedBean.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/transactional/OneManagedBean.java
@@ -58,7 +58,7 @@ public class OneManagedBean {
     public OneManagedBean() {
     }
 
-    @Transactional(value = TxType.REQUIRED, readOnly = true)
+    @Transactional(value = TxType.REQUIRED, isReadOnly = true)
     public String txTypeRequiredReadOnly() {
         String result = "not readOnly";
         if (tsr.isReadOnly()) {
@@ -67,7 +67,7 @@ public class OneManagedBean {
         return result;
     }
 
-    @Transactional(value = TxType.REQUIRES_NEW, readOnly = true)
+    @Transactional(value = TxType.REQUIRES_NEW, isReadOnly = true)
     public String txTypeRequiresNewReadOnly() {
         String result = "not readOnly";
         if (tsr.isReadOnly()) {

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClient.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClient.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * @(#)UserSetTransactionTimeoutClient.java	1.21 03/05/16
+ */
+
+package com.sun.ts.tests.jta.ee.usertransaction.setreadonly;
+
+import java.io.Serializable;
+import java.util.Properties;
+
+import com.sun.ts.lib.harness.ServiceEETest;
+import com.sun.ts.tests.jta.ee.common.Transact;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Status;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.UserTransaction;
+
+/**
+ * The UserSetReadOnlyClient class tests setReadOnly() method of UserTransaction interface using
+ * Sun's J2EE Reference Implementation.
+ */
+
+public class UserSetReadOnlyClient extends ServiceEETest implements Serializable {
+    private static final String testName = "jta.ee.usertransaction.setreadonly";
+
+    private UserTransaction userTransaction = null;
+
+    public void setup(String[] args, Properties p) throws Exception {
+        try {
+            // Initializes the Environment
+            Transact.init();
+            logTrace("Test environment initialized");
+
+            // Gets the User Transaction
+            userTransaction = (UserTransaction) Transact.nctx.lookup("java:comp/UserTransaction");
+            logMsg("User Transaction object is Obtained");
+
+            if (userTransaction == null) {
+                logErr("Unable to get User Transaction" + " Instance : Could not proceed with" + " tests");
+                throw new Exception("couldnt proceed further");
+            } else if (userTransaction.getStatus() == Status.STATUS_ACTIVE) {
+                userTransaction.rollback();
+            }
+        } catch (Exception exception) {
+            logErr("Setup Failed!");
+            logTrace("Unable to get User Transaction Instance :" + " Could not proceed with tests");
+            throw new Exception("Setup Failed", exception);
+        }
+    }// End of setup
+
+    public static void main(String args[]) {
+        UserSetReadOnlyClient userSetTransTout = new UserSetReadOnlyClient();
+        com.sun.ts.lib.harness.Status s = userSetTransTout.run(args, System.out, System.err);
+        s.exit();
+
+    } // End of main
+
+    // Beginning of TestCases
+
+    /**
+     * @testName: testUserSetReadOnly001
+     * @test_Strategy: Before starting the User Transaction set the transaction read-only mode to true.
+     */
+    public void testUserSetReadOnly001() throws Exception {
+        boolean pass1 = false;
+        boolean pass2 = false;
+        boolean pass3 = false;
+
+        try {
+            if (!userTransaction.isReadOnly()) {
+                pass1 = true;
+            }
+
+            // Sets the readOnly value for the current transaction
+            userTransaction.setReadOnly(true);
+
+            // Starts a Global Transaction & associates with
+            // Current Thread.
+            userTransaction.begin();
+            logMsg("UserTransaction Started");
+
+            if (userTransaction.isReadOnly()) {
+                logMsg("UserTransaction readOnly is true");
+                pass2 = true;
+            }
+
+            // Commits the transaction.
+            userTransaction.commit();
+
+            if (!userTransaction.isReadOnly()) {
+                pass3 = true;
+            }
+
+            if (pass1 && pass2 && pass3) {
+                logMsg( "testUserSetReadOnly001 Passed" );
+            } else if (!pass1) {
+                throw new Exception("UserTransaction isReadOnly expected false on non active transaction");
+            } else if (!pass2) {
+                throw new Exception("UserTransaction isReadOnly expected true on new active transaction after setReadOnly");
+            } else {
+                throw new Exception("UserTransaction isReadOnly expected false on non active transaction");
+            }
+        } catch (Exception exception) {
+            logErr("Exception " + exception.toString() + " was caught");
+            throw new Exception("Exception was not thrown as" + " Expected in commit()", exception);
+        }
+
+    }// End of testUserSetReadOnly001
+
+    /**
+     * @testName: testUserSetReadOnly002
+     * @test_Strategy: After starting the User Transaction set the transaction read-only mode to true.
+     */
+
+    public void testUserSetReadOnly002() throws Exception {
+        boolean pass1 = false;
+        boolean pass2 = false;
+        boolean pass3 = false;
+
+        try {
+            if (!userTransaction.isReadOnly()) {
+                pass1 = true;
+            }
+            // Starts a Global Transaction & associates with
+            // Current Thread.
+            userTransaction.begin();
+            logMsg("UserTransaction Started");
+
+            // Sets the readOnly value for the current transaction
+            userTransaction.setReadOnly(true);
+
+            if (!userTransaction.isReadOnly()) {
+                pass2 = true;
+            }
+
+            // Commits the transaction.
+            userTransaction.commit();
+
+            if (!userTransaction.isReadOnly()) {
+                pass3 = true;
+            }
+
+            if (pass1 && pass2 && pass3) {
+                logMsg( "testUserSetReadOnly002 Passed" );
+            } else if (!pass1) {
+                throw new Exception("UserTransaction isReadOnly expected false on non active transaction");
+            } else if (!pass2) {
+                throw new Exception("UserTransaction isReadOnly expected false on existing active transaction after setReadOnly");
+            } else {
+                throw new Exception("UserTransaction isReadOnly expected false on non active transaction");
+            }
+        } catch (SystemException system) {
+            logErr("Exception " + system.toString() + " was caught");
+            throw new Exception("UnExpected Exception was caught:" + " Failed", system);
+        } catch (Exception exception) {
+            logErr("Exception " + exception.toString() + " was caught");
+            throw new Exception("UnExpected Exception was caught:" + " Failed", exception);
+        }
+
+    }// End of testUserSetReadOnly002
+
+    public void cleanup() throws Exception {
+        try {
+            // Removing noisy stack trace.
+            if (userTransaction.getStatus() == Status.STATUS_ACTIVE) {
+                // Frees Current Thread, from Transaction
+                Transact.free();
+                try {
+                    userTransaction.rollback();
+                } catch (Exception exception) {
+                    throw new Exception(exception.getCause());
+                }
+                int retries = 1;
+                while ((userTransaction.getStatus() != Status.STATUS_NO_TRANSACTION) && (retries <= 5)) {
+                    logMsg("cleanup(): retry # " + retries);
+                    try {
+                        Thread.sleep(1000);
+                    } catch (Exception e) {
+                        throw new Exception(e.getCause());
+                    }
+                    retries++;
+                }
+                logMsg("Cleanup ok;");
+            } else {
+                logMsg("CleanUp not required as Transaction is not in Active state.");
+            }
+        } catch (Exception exception) {
+            logErr("Cleanup Failed", exception);
+            logTrace("Could not clean the environment");
+        }
+
+    }// End of cleanup
+
+}// End of UserSetReadOnlyClient

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClient.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClient.java
@@ -80,6 +80,7 @@ public class UserSetReadOnlyClient extends ServiceEETest implements Serializable
         boolean pass1 = false;
         boolean pass2 = false;
         boolean pass3 = false;
+        boolean pass4 = false;
 
         try {
             if (!userTransaction.isReadOnly()) {
@@ -96,25 +97,34 @@ public class UserSetReadOnlyClient extends ServiceEETest implements Serializable
                 pass2 = true;
             }
 
-            // Commits the transaction.
-            userTransaction.commit();
-
-            if (!userTransaction.isReadOnly()) {
+            // A read-only transaction's only permitted outcome is to roll
+            // back: commit() must roll the transaction back and throw
+            // RollbackException.
+            try {
+                userTransaction.commit();
+            } catch (RollbackException rollback) {
+                logMsg("RollbackException was caught as expected in commit()");
                 pass3 = true;
             }
 
-            if (pass1 && pass2 && pass3) {
+            if (!userTransaction.isReadOnly()) {
+                pass4 = true;
+            }
+
+            if (pass1 && pass2 && pass3 && pass4) {
                 logMsg( "testUserSetReadOnly001 Passed" );
             } else if (!pass1) {
                 throw new Exception("UserTransaction isReadOnly expected false on non active transaction");
             } else if (!pass2) {
                 throw new Exception("UserTransaction isReadOnly expected true on new active transaction after setReadOnly");
+            } else if (!pass3) {
+                throw new Exception("RollbackException was not thrown as expected in commit()");
             } else {
                 throw new Exception("UserTransaction isReadOnly expected false on non active transaction");
             }
-        } catch (Exception exception) {
-            logErr("Exception " + exception.toString() + " was caught");
-            throw new Exception("Exception was not thrown as" + " Expected in commit()", exception);
+        } catch (SystemException system) {
+            logErr("Exception " + system.toString() + " was caught");
+            throw new Exception("UnExpected Exception was caught:" + " Failed", system);
         }
 
     }// End of testUserSetReadOnly001

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClient.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClient.java
@@ -23,7 +23,7 @@ package com.sun.ts.tests.jta.ee.usertransaction.setreadonly;
 import java.io.Serializable;
 import java.util.Properties;
 
-import com.sun.ts.lib.harness.ServiceEETest;
+import com.sun.ts.tests.common.base.ServiceEETest;
 import com.sun.ts.tests.jta.ee.common.Transact;
 import jakarta.transaction.RollbackException;
 import jakarta.transaction.Status;
@@ -86,12 +86,9 @@ public class UserSetReadOnlyClient extends ServiceEETest implements Serializable
                 pass1 = true;
             }
 
-            // Sets the readOnly value for the current transaction
-            userTransaction.setReadOnly(true);
-
-            // Starts a Global Transaction & associates with
+            // Starts a read-only Global Transaction & associates with
             // Current Thread.
-            userTransaction.begin();
+            userTransaction.begin(true);
             logMsg("UserTransaction Started");
 
             if (userTransaction.isReadOnly()) {
@@ -141,9 +138,7 @@ public class UserSetReadOnlyClient extends ServiceEETest implements Serializable
             userTransaction.begin();
             logMsg("UserTransaction Started");
 
-            // Sets the readOnly value for the current transaction
-            userTransaction.setReadOnly(true);
-
+            // setReadOnly on an already-active transaction has no effect
             if (!userTransaction.isReadOnly()) {
                 pass2 = true;
             }

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientEjbTest.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientEjbTest.java
@@ -1,0 +1,131 @@
+package com.sun.ts.tests.jta.ee.usertransaction.setreadonly;
+
+import java.lang.System.Logger;
+import java.net.URL;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("jta")
+@Tag("platform")
+@Tag("tck-appclient")
+
+public class UserSetReadOnlyClientEjbTest
+        extends UserSetReadOnlyClient {
+    static final String VEHICLE_ARCHIVE = "setreadonly_ejb_vehicle";
+
+    private static String packagePath = UserSetReadOnlyClientEjbTest.class.getPackageName().replace( ".", "/");
+
+    private static final Logger logger = System.getLogger( UserSetReadOnlyClientEjbTest.class.getName());
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    @Override
+    @AfterEach
+    public void cleanup() {
+        logger.log(Logger.Level.INFO, "cleanup ok");
+    }
+
+    @TargetsContainer("tck-appclient")
+    @OverProtocol("appclient")
+    @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+    public static EnterpriseArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+        JavaArchive setreadonly_ejb_vehicle_client = ShrinkWrap.create(JavaArchive.class,
+                "setreadonly_ejb_vehicle_client.jar");
+        setreadonly_ejb_vehicle_client.addClasses(com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+                com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class, com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class,
+                Fault.class, com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.class,
+                com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRunner.class, com.sun.ts.lib.harness.EETest.class,
+                com.sun.ts.lib.harness.ServiceEETest.class, SetupException.class,
+                com.sun.ts.tests.common.vehicle.VehicleClient.class, com.sun.ts.tests.jta.ee.common.Transact.class,
+                com.sun.ts.tests.jta.ee.common.TransactionStatus.class, com.sun.ts.tests.jta.ee.common.InvalidStatusException.class,
+                com.sun.ts.tests.jta.ee.common.InitFailedException.class, UserSetReadOnlyClient.class,
+                UserSetReadOnlyClientEjbTest.class);
+        // The application-client.xml descriptor
+        URL resURL = UserSetReadOnlyClientEjbTest.class.getClassLoader().getResource( packagePath + "/ejb_vehicle_client.xml");
+        if (resURL != null) {
+            setreadonly_ejb_vehicle_client.addAsManifestResource(resURL, "application-client.xml");
+        }
+        resURL = UserSetReadOnlyClientEjbTest.class.getClassLoader()
+                .getResource(packagePath + "/setreadonly_ejb_vehicle_client.jar.sun-application-client.xml");
+        if (resURL != null) {
+            setreadonly_ejb_vehicle_client.addAsManifestResource(resURL, "sun-application-client.xml");
+        }
+        setreadonly_ejb_vehicle_client.addAsManifestResource(
+                new StringAsset("Main-Class: " + UserSetReadOnlyClientEjbTest.class.getName() + "\n"), "MANIFEST.MF");
+        archiveProcessor.processClientArchive(setreadonly_ejb_vehicle_client, UserSetReadOnlyClientEjbTest.class,
+                resURL);
+
+        JavaArchive setreadonly_ejb_vehicle_ejb = ShrinkWrap.create(JavaArchive.class,
+                "setreadonly_ejb_vehicle_ejb.jar");
+        setreadonly_ejb_vehicle_ejb.addClasses(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+                Fault.class, com.sun.ts.tests.jta.ee.common.Transact.class,
+                com.sun.ts.tests.jta.ee.common.InvalidStatusException.class,
+                UserSetReadOnlyClient.class,
+                com.sun.ts.tests.common.vehicle.ejb.EJBVehicle.class, com.sun.ts.tests.jta.ee.common.InitFailedException.class,
+                com.sun.ts.tests.jta.ee.common.TransactionStatus.class, com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+                com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class, com.sun.ts.lib.harness.EETest.class,
+                com.sun.ts.lib.harness.ServiceEETest.class, SetupException.class,
+                com.sun.ts.tests.common.vehicle.VehicleClient.class, UserSetReadOnlyClientEjbTest.class);
+        // The ejb-jar.xml descriptor
+        URL ejbResURL = UserSetReadOnlyClientEjbTest.class.getClassLoader().getResource( packagePath + "/ejb_vehicle_ejb.xml");
+        if (ejbResURL != null) {
+            setreadonly_ejb_vehicle_ejb.addAsManifestResource(ejbResURL, "ejb-jar.xml");
+        }
+        // The sun-ejb-jar.xml file
+        ejbResURL = UserSetReadOnlyClientEjbTest.class.getClassLoader()
+                .getResource(packagePath + "/setreadonly_ejb_vehicle_ejb.jar.sun-ejb-jar.xml");
+        if (ejbResURL != null) {
+            setreadonly_ejb_vehicle_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
+        }
+        archiveProcessor.processEjbArchive( setreadonly_ejb_vehicle_ejb, UserSetReadOnlyClientEjbTest.class, ejbResURL);
+
+        EnterpriseArchive setreadonly_ejb_vehicle_ear = ShrinkWrap.create(EnterpriseArchive.class,
+                "setreadonly_ejb_vehicle.ear");
+        setreadonly_ejb_vehicle_ear.addAsModule(setreadonly_ejb_vehicle_ejb);
+        setreadonly_ejb_vehicle_ear.addAsModule(setreadonly_ejb_vehicle_client);
+
+        return setreadonly_ejb_vehicle_ear;
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("ejb")
+    public void testUserSetReadOnly001() throws Exception {
+        super.testUserSetReadOnly001();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("ejb")
+    public void testUserSetReadOnly002() throws Exception {
+        super.testUserSetReadOnly002();
+    }
+
+}

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientEjbTest.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientEjbTest.java
@@ -3,6 +3,10 @@ package com.sun.ts.tests.jta.ee.usertransaction.setreadonly;
 import java.lang.System.Logger;
 import java.net.URL;
 
+import com.sun.ts.lib.harness.Fault;
+import com.sun.ts.lib.harness.SetupException;
+import com.sun.ts.tests.common.base.EETest;
+import com.sun.ts.tests.common.base.ServiceEETest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -61,8 +65,8 @@ public class UserSetReadOnlyClientEjbTest
         setreadonly_ejb_vehicle_client.addClasses(com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
                 com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class, com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class,
                 Fault.class, com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.class,
-                com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRunner.class, com.sun.ts.lib.harness.EETest.class,
-                com.sun.ts.lib.harness.ServiceEETest.class, SetupException.class,
+                com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRunner.class, EETest.class,
+                ServiceEETest.class, SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class, com.sun.ts.tests.jta.ee.common.Transact.class,
                 com.sun.ts.tests.jta.ee.common.TransactionStatus.class, com.sun.ts.tests.jta.ee.common.InvalidStatusException.class,
                 com.sun.ts.tests.jta.ee.common.InitFailedException.class, UserSetReadOnlyClient.class,
@@ -90,8 +94,8 @@ public class UserSetReadOnlyClientEjbTest
                 UserSetReadOnlyClient.class,
                 com.sun.ts.tests.common.vehicle.ejb.EJBVehicle.class, com.sun.ts.tests.jta.ee.common.InitFailedException.class,
                 com.sun.ts.tests.jta.ee.common.TransactionStatus.class, com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
-                com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class, com.sun.ts.lib.harness.EETest.class,
-                com.sun.ts.lib.harness.ServiceEETest.class, SetupException.class,
+                com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class, EETest.class,
+                ServiceEETest.class, SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class, UserSetReadOnlyClientEjbTest.class);
         // The ejb-jar.xml descriptor
         URL ejbResURL = UserSetReadOnlyClientEjbTest.class.getClassLoader().getResource( packagePath + "/ejb_vehicle_ejb.xml");

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientJspTest.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientJspTest.java
@@ -1,0 +1,107 @@
+package com.sun.ts.tests.jta.ee.usertransaction.setreadonly;
+
+import java.lang.System.Logger;
+import java.net.URL;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("jta")
+@Tag("platform")
+@Tag("web")
+@Tag("tck-javatest")
+
+public class UserSetReadOnlyClientJspTest
+        extends UserSetReadOnlyClient {
+    static final String VEHICLE_ARCHIVE = "setreadonly_jsp_vehicle";
+
+    private static String packagePath = UserSetReadOnlyClientJspTest.class.getPackageName().replace( ".", "/");
+
+    private static final Logger logger = System.getLogger( UserSetReadOnlyClientJspTest.class.getName());
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    @Override
+    @AfterEach
+    public void cleanup() {
+        logger.log(Logger.Level.INFO, "cleanup ok");
+    }
+
+    @TargetsContainer("tck-javatest")
+    @OverProtocol("javatest")
+    @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+    public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+        WebArchive setreadonly_jsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "setreadonly_jsp_vehicle_web.war");
+        setreadonly_jsp_vehicle_web.addClasses(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+                Fault.class, com.sun.ts.tests.jta.ee.common.Transact.class,
+                com.sun.ts.tests.jta.ee.common.InvalidStatusException.class,
+                UserSetReadOnlyClient.class,
+                com.sun.ts.tests.jta.ee.common.InitFailedException.class, com.sun.ts.tests.jta.ee.common.TransactionStatus.class,
+                com.sun.ts.tests.common.vehicle.VehicleRunnable.class, com.sun.ts.tests.jta.ee.common.InvalidStatusException.class,
+                com.sun.ts.tests.jta.ee.common.InitFailedException.class, com.sun.ts.lib.harness.EETest.class,
+                com.sun.ts.lib.harness.ServiceEETest.class, com.sun.ts.tests.jta.ee.common.TransactionStatus.class,
+                SetupException.class, com.sun.ts.tests.common.vehicle.VehicleClient.class,
+                UserSetReadOnlyClientJspTest.class);
+        // The web.xml descriptor
+        URL warResURL = UserSetReadOnlyClientJspTest.class.getClassLoader().getResource( packagePath + "/jsp_vehicle_web.xml");
+        if (warResURL != null) {
+            setreadonly_jsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+        }
+        warResURL = UserSetReadOnlyClientJspTest.class.getResource( "/vehicle/jsp/contentRoot/client.html");
+        setreadonly_jsp_vehicle_web.addAsWebResource(warResURL, "/client.html");
+        warResURL = UserSetReadOnlyClientJspTest.class.getResource( "/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
+        setreadonly_jsp_vehicle_web.addAsWebResource(warResURL, "/jsp_vehicle.jsp");
+
+        warResURL = UserSetReadOnlyClientJspTest.class.getClassLoader()
+                .getResource(packagePath + "/setreadonly_jsp_vehicle_web.war.sun-web.xml");
+        if (warResURL != null) {
+            setreadonly_jsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+        }
+        archiveProcessor.processWebArchive( setreadonly_jsp_vehicle_web, UserSetReadOnlyClientJspTest.class, warResURL);
+
+        return setreadonly_jsp_vehicle_web;
+        // EnterpriseArchive setreadonly_jsp_vehicle_ear = ShrinkWrap.create(EnterpriseArchive.class,
+        // "setreadonly_jsp_vehicle.ear");
+        // setreadonly_jsp_vehicle_ear.addAsModule(setreadonly_jsp_vehicle_web);
+        // return setreadonly_jsp_vehicle_ear;
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("jsp")
+    public void testUserSetReadOnly001() throws Exception {
+        super.testUserSetReadOnly001();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("jsp")
+    public void testUserSetReadOnly002() throws Exception {
+        super.testUserSetReadOnly002();
+    }
+
+}

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientJspTest.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientJspTest.java
@@ -3,6 +3,10 @@ package com.sun.ts.tests.jta.ee.usertransaction.setreadonly;
 import java.lang.System.Logger;
 import java.net.URL;
 
+import com.sun.ts.lib.harness.Fault;
+import com.sun.ts.lib.harness.SetupException;
+import com.sun.ts.tests.common.base.EETest;
+import com.sun.ts.tests.common.base.ServiceEETest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -62,8 +66,8 @@ public class UserSetReadOnlyClientJspTest
                 UserSetReadOnlyClient.class,
                 com.sun.ts.tests.jta.ee.common.InitFailedException.class, com.sun.ts.tests.jta.ee.common.TransactionStatus.class,
                 com.sun.ts.tests.common.vehicle.VehicleRunnable.class, com.sun.ts.tests.jta.ee.common.InvalidStatusException.class,
-                com.sun.ts.tests.jta.ee.common.InitFailedException.class, com.sun.ts.lib.harness.EETest.class,
-                com.sun.ts.lib.harness.ServiceEETest.class, com.sun.ts.tests.jta.ee.common.TransactionStatus.class,
+                com.sun.ts.tests.jta.ee.common.InitFailedException.class, EETest.class,
+                ServiceEETest.class, com.sun.ts.tests.jta.ee.common.TransactionStatus.class,
                 SetupException.class, com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 UserSetReadOnlyClientJspTest.class);
         // The web.xml descriptor

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientServletTest.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientServletTest.java
@@ -1,0 +1,108 @@
+package com.sun.ts.tests.jta.ee.usertransaction.setreadonly;
+
+import java.lang.System.Logger;
+import java.net.URL;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("jta")
+@Tag("platform")
+@Tag("web")
+@Tag("tck-javatest")
+
+public class UserSetReadOnlyClientServletTest
+        extends UserSetReadOnlyClient {
+    static final String VEHICLE_ARCHIVE = "setreadonly_servlet_vehicle";
+
+    private static String packagePath = UserSetReadOnlyClientServletTest.class.getPackageName().replace( ".", "/");
+
+    private static final Logger logger = System.getLogger( UserSetReadOnlyClientServletTest.class.getName());
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    @Override
+    @AfterEach
+    public void cleanup() {
+        logger.log(Logger.Level.INFO, "cleanup ok");
+    }
+
+    @TargetsContainer("tck-javatest")
+    @OverProtocol("javatest")
+    @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+    public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+        // War
+        // the war with the correct archive name
+        WebArchive setreadonly_servlet_vehicle_web = ShrinkWrap.create(WebArchive.class,
+                "setreadonly_servlet_vehicle_web.war");
+        // The class files
+        setreadonly_servlet_vehicle_web.addClasses(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+                Fault.class, com.sun.ts.tests.jta.ee.common.Transact.class,
+                com.sun.ts.tests.jta.ee.common.InvalidStatusException.class,
+                UserSetReadOnlyClient.class,
+                com.sun.ts.tests.jta.ee.common.InitFailedException.class, com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.class,
+                com.sun.ts.tests.jta.ee.common.TransactionStatus.class, com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+                com.sun.ts.tests.jta.ee.common.InvalidStatusException.class, com.sun.ts.tests.jta.ee.common.InitFailedException.class,
+                com.sun.ts.lib.harness.EETest.class, com.sun.ts.lib.harness.ServiceEETest.class,
+                com.sun.ts.tests.jta.ee.common.TransactionStatus.class, SetupException.class,
+                com.sun.ts.tests.common.vehicle.VehicleClient.class, UserSetReadOnlyClientServletTest.class);
+        // The web.xml descriptor
+        URL warResURL = UserSetReadOnlyClientServletTest.class.getClassLoader()
+                .getResource(packagePath + "/servlet_vehicle_web.xml");
+        if (warResURL != null) {
+            setreadonly_servlet_vehicle_web.setWebXML(warResURL);
+        }
+        warResURL = UserSetReadOnlyClientServletTest.class.getClassLoader()
+                .getResource(packagePath + "/setreadonly_servlet_vehicle_web.war.sun-web.xml");
+        if (warResURL != null) {
+            setreadonly_servlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+        }
+        archiveProcessor.processWebArchive(setreadonly_servlet_vehicle_web, UserSetReadOnlyClientServletTest.class,
+                warResURL);
+
+        return setreadonly_servlet_vehicle_web;
+        // EnterpriseArchive setreadonly_servlet_vehicle_ear = ShrinkWrap.create(EnterpriseArchive.class,
+        // "setreadonly_servlet_vehicle.ear");
+        // setreadonly_servlet_vehicle_ear.addAsModule(setreadonly_servlet_vehicle_web);
+        // return setreadonly_servlet_vehicle_ear;
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("servlet")
+    public void testUserSetReadOnly001() throws Exception {
+        super.testUserSetReadOnly001();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("servlet")
+    public void testUserSetReadOnly002() throws Exception {
+        super.testUserSetReadOnly002();
+    }
+
+}

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientServletTest.java
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientServletTest.java
@@ -3,6 +3,10 @@ package com.sun.ts.tests.jta.ee.usertransaction.setreadonly;
 import java.lang.System.Logger;
 import java.net.URL;
 
+import com.sun.ts.lib.harness.Fault;
+import com.sun.ts.lib.harness.SetupException;
+import com.sun.ts.tests.common.base.EETest;
+import com.sun.ts.tests.common.base.ServiceEETest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -67,7 +71,7 @@ public class UserSetReadOnlyClientServletTest
                 com.sun.ts.tests.jta.ee.common.InitFailedException.class, com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.class,
                 com.sun.ts.tests.jta.ee.common.TransactionStatus.class, com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
                 com.sun.ts.tests.jta.ee.common.InvalidStatusException.class, com.sun.ts.tests.jta.ee.common.InitFailedException.class,
-                com.sun.ts.lib.harness.EETest.class, com.sun.ts.lib.harness.ServiceEETest.class,
+                EETest.class, ServiceEETest.class,
                 com.sun.ts.tests.jta.ee.common.TransactionStatus.class, SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class, UserSetReadOnlyClientServletTest.class);
         // The web.xml descriptor

--- a/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/build.xml
+++ b/tck/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/build.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project name="jta_ee_usertransaction_setreadonly" basedir="." default="usage">
+<import file="../../../../../../../../../bin/xml/ts.import.xml"/> 
+
+  <property name="includes"
+            value="com/sun/ts/tests/jta/ee/common/Transact.class,
+                   com/sun/ts/tests/jta/ee/common/TransactionStatus.class,
+                   com/sun/ts/tests/jta/ee/common/InvalidStatusException.class,
+                   com/sun/ts/tests/jta/ee/common/InitFailedException.class"/>
+  
+  <target name="package">
+      <ts.vehicles name="setreadonly">
+        <ejb-elements>
+          <fileset dir="${class.dir}" includes="${includes}"/>
+        </ejb-elements>
+        <servlet-elements>
+          <zipfileset dir="${class.dir}" includes="${includes}"
+                      prefix="WEB-INF/classes"/>
+        </servlet-elements>
+        <jsp-elements>
+          <zipfileset dir="${class.dir}" includes="${includes}"
+                      prefix="WEB-INF/classes"/>
+        </jsp-elements>
+      </ts.vehicles>
+  </target>
+
+</project>

--- a/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/appclient_vehicle_client.xml
+++ b/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/appclient_vehicle_client.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<application-client version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd">
+  <description>TS app client UserSetReadOnly</description>
+  <display-name>setreadonly_client</display-name>
+  <ejb-ref>
+    <ejb-ref-name>ejb/EJBVehicle</ejb-ref-name>
+    <ejb-ref-type>Session</ejb-ref-type>
+    <remote>com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote</remote>
+  </ejb-ref>
+  <resource-ref>
+    <res-ref-name>jdbc/DB1</res-ref-name>
+    <res-type>javax.sql.DataSource</res-type>
+    <res-auth>Container</res-auth>
+    <res-sharing-scope>Shareable</res-sharing-scope>
+  </resource-ref>
+</application-client>

--- a/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/ejb_vehicle_client.xml
+++ b/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/ejb_vehicle_client.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<application-client version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd">
+  <description>TS ejbvehicle client</description>
+  <display-name>setreadonly_ejb_vehicle_client</display-name>
+  <ejb-ref>
+    <ejb-ref-name>ejb/EJBVehicle</ejb-ref-name>
+    <ejb-ref-type>Session</ejb-ref-type>
+    <remote>com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote</remote>
+  </ejb-ref>
+</application-client>

--- a/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/ejb_vehicle_ejb.xml
+++ b/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/ejb_vehicle_ejb.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<ejb-jar version="4.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd">
+  <display-name>Ejb1</display-name>
+  <enterprise-beans>
+    <session>
+      <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
+      <business-remote>com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote</business-remote>
+      <ejb-class>com.sun.ts.tests.common.vehicle.ejb.EJBVehicle</ejb-class>
+      <session-type>Stateful</session-type>
+      <transaction-type>Bean</transaction-type>
+      <resource-ref>
+        <description>description</description>
+        <res-ref-name>jdbc/DB1</res-ref-name>
+        <res-type>javax.sql.DataSource</res-type>
+        <res-auth>Application</res-auth>
+        <res-sharing-scope>Shareable</res-sharing-scope>
+      </resource-ref>
+      <security-identity>
+        <use-caller-identity/>
+      </security-identity>
+    </session>
+  </enterprise-beans>
+</ejb-jar>

--- a/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/jsp_vehicle_web.xml
+++ b/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/jsp_vehicle_web.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+  <display-name>setreadonly_jsp_vehicle</display-name>
+  <servlet>
+    <servlet-name>jsp_vehicle</servlet-name>
+    <jsp-file>/jsp_vehicle.jsp</jsp-file>
+    <load-on-startup>0</load-on-startup>
+  </servlet>
+  <session-config>
+    <session-timeout>54</session-timeout>
+  </session-config>
+  <resource-ref>
+    <res-ref-name>jdbc/DB1</res-ref-name>
+    <res-type>javax.sql.DataSource</res-type>
+    <res-auth>Container</res-auth>
+    <res-sharing-scope>Shareable</res-sharing-scope>
+  </resource-ref>
+</web-app>

--- a/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/servlet_vehicle_web.xml
+++ b/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/servlet_vehicle_web.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+  <display-name>setreadonly_servlet_vehicle</display-name>
+  <servlet>
+    <servlet-name>Servlet_VehicleLogicalName</servlet-name>
+    <servlet-class>com.sun.ts.tests.common.vehicle.servlet.ServletVehicle</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>Servlet_VehicleLogicalName</servlet-name>
+    <url-pattern>/servlet_vehicle</url-pattern>
+  </servlet-mapping>
+  <session-config>
+    <session-timeout>54</session-timeout>
+  </session-config>
+  <resource-ref>
+    <res-ref-name>jdbc/DB1</res-ref-name>
+    <res-type>javax.sql.DataSource</res-type>
+    <res-auth>Container</res-auth>
+    <res-sharing-scope>Shareable</res-sharing-scope>
+  </resource-ref>
+</web-app>

--- a/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_ejb_vehicle_client.jar.sun-application-client.xml
+++ b/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_ejb_vehicle_client.jar.sun-application-client.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-application-client PUBLIC "-//Sun Microsystems, Inc.//DTD Sun ONE Application Server 8.0 Application Client 1.4//EN" "http://www.sun.com/software/sunone/appserver/dtds/sun-application-client_1_4-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-application-client>
+  <ejb-ref>
+    <ejb-ref-name>ejb/EJBVehicle</ejb-ref-name>
+    <jndi-name>setreadonly_ejb_vehicle</jndi-name>
+  </ejb-ref>
+</sun-application-client>

--- a/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_ejb_vehicle_ejb.jar.sun-ejb-jar.xml
+++ b/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_ejb_vehicle_ejb.jar.sun-ejb-jar.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Sun ONE Application Server 8.0 EJB 2.1//EN" "http://www.sun.com/software/sunone/appserver/dtds/sun-ejb-jar_2_1-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-ejb-jar>
+  <enterprise-beans>
+    <unique-id>0</unique-id>
+    <ejb>
+      <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
+      <jndi-name>setreadonly_ejb_vehicle</jndi-name>
+      <resource-ref>
+        <res-ref-name>jdbc/DB1</res-ref-name>
+        <jndi-name>jdbc/DB1</jndi-name>
+        <default-resource-principal>
+          <name>user1</name>
+          <password>password1</password>
+        </default-resource-principal>
+      </resource-ref>
+      <pass-by-reference>false</pass-by-reference>
+      <ior-security-config>
+        <transport-config>
+          <integrity>supported</integrity>
+          <confidentiality>supported</confidentiality>
+          <establish-trust-in-target>supported</establish-trust-in-target>
+          <establish-trust-in-client>supported</establish-trust-in-client>
+        </transport-config>
+        <as-context>
+          <auth-method>username_password</auth-method>
+          <realm>default</realm>
+          <required>false</required>
+        </as-context>
+        <sas-context>
+          <caller-propagation>supported</caller-propagation>
+        </sas-context>
+      </ior-security-config>
+      <is-read-only-bean>false</is-read-only-bean>
+      <refresh-period-in-seconds>-1</refresh-period-in-seconds>
+      <gen-classes/>
+    </ejb>
+  </enterprise-beans>
+</sun-ejb-jar>

--- a/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_jsp_vehicle_web.war.sun-web.xml
+++ b/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_jsp_vehicle_web.war.sun-web.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Sun ONE Application Server 8.0 Servlet 2.4//EN" "http://www.sun.com/software/sunone/appserver/dtds/sun-web-app_2_4-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-web-app>
+  <resource-ref>
+    <res-ref-name>jdbc/DB1</res-ref-name>
+    <jndi-name>jdbc/DB1</jndi-name>
+    <default-resource-principal>
+      <name>user1</name>
+      <password>password1</password>
+    </default-resource-principal>
+  </resource-ref>
+</sun-web-app>

--- a/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_servlet_vehicle_web.war.sun-web.xml
+++ b/tck/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_servlet_vehicle_web.war.sun-web.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Sun ONE Application Server 8.0 Servlet 2.4//EN" "http://www.sun.com/software/sunone/appserver/dtds/sun-web-app_2_4-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-web-app>
+  <resource-ref>
+    <res-ref-name>jdbc/DB1</res-ref-name>
+    <jndi-name>jdbc/DB1</jndi-name>
+    <default-resource-principal>
+      <name>user1</name>
+      <password>password1</password>
+    </default-resource-principal>
+  </resource-ref>
+</sun-web-app>


### PR DESCRIPTION
Added 4 commits from https://github.com/jakartaee/platform-tck/pull/2462, excluding the connector-whitebox additions.

The connector-whitebox additions are here: https://github.com/jakartaee/platform-tck/pull/2732.

The tck requires the connector and updated connector-whitebox in the platform-tck repo be built before. Since platform-tck has not moved to EE12 dependencies yet, the #2732 will not be merged for a bit. Similarly, since this change will not build without #2732, it should not be merged yet. 

I also amended the TCK tests to not use the setReadOnly method as it was removed earlier here: https://github.com/jakartaee/transactions/commit/f9d1dc01d59493e70fdef67d1b1e9c10ef132887

The tck tests now also expect rollback when a user tries to call commit on it (previously it just silently rolled back). This is due to this line in the api (transaction.java): 

"When the transaction ends, if requested to commit, the transaction manager must roll back each
     * {@code XAResource}, raising {@link RollbackException} to the caller."

@tomjenkinson @scottmarlow @beikov @njr-11 