### PR TITLE
Changed name of TCK to Jakarta Transactions TCK

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -29,8 +29,8 @@
     <artifactId>transactions-tck</artifactId>
     <version>12.0.0-SNAPSHOT</version>
 
-    <name>Jakarta Transactions</name>
-    <description>Jakarta Transactions</description>
+    <name>Jakarta Transactions TCK</name>
+    <description>Jakarta Transactions TCK</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Changed TCK name from "Jakarta Transactions" to "Jakarta Transactions TCK"

Summary now looks like this when build from root: 

[INFO] Reactor Summary:
[INFO] 
[INFO] jakarta.transaction API 2.0.2-SNAPSHOT ............. SUCCESS [  3.753 s]
[INFO] Jakarta Transactions TCK 12.0.0-SNAPSHOT ........... SUCCESS [  1.228 s]
[INFO] Jakarta Transactions Specification 2.1 ............. SUCCESS [  4.932 s]
[INFO] Jakarta transactions Parent 2.0.2-SNAPSHOT ......... SUCCESS [  0.325 s]